### PR TITLE
add SGO attribute "altitude" and NTO node "WeatherStation"

### DIFF
--- a/NTO/Meteorology/entities/WeatherStation.ttl
+++ b/NTO/Meteorology/entities/WeatherStation.ttl
@@ -1,0 +1,33 @@
+@prefix dcterms:                <http://purl.org/dc/terms/> .
+@prefix ogit:                   <http://www.purl.org/ogit/> .
+@prefix ogit.Meteorology:       <http://www.purl.org/ogit/Meteorology/> .
+@prefix owl:                    <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
+
+
+ogit.Meteorology:WeatherStation
+    a rdfs:Class;
+    rdfs:subClassOf     ogit:Entity;
+    rdfs:label          "WeatherStation";
+    dcterms:description "Represents a physical weather observation site.";
+    dcterms:valid       "start=2025-10-15;";
+    dcterms:creator     "Markus Noack";
+    ogit:scope          "NTO";
+    ogit:parent         ogit:Node;
+    ogit:mandatory-attributes (
+        ogit:latitude
+        ogit:longitude
+        ogit:altitude
+    );
+    ogit:optional-attributes (
+        ogit:name
+    );
+    ogit:indexed-attributes (
+        ogit:name
+    );
+    ogit:allowed (
+        [ ogit:locatedIn ogit:Region ]
+        [ ogit:locatedIn ogit:Location ]
+        [ ogit:generates ogit:Timeseries ]
+    );
+.

--- a/SGO/sgo/attributes/altitude.ttl
+++ b/SGO/sgo/attributes/altitude.ttl
@@ -1,0 +1,13 @@
+@prefix ogit:                   <http://www.purl.org/ogit/> .
+@prefix owl:                    <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                <http://purl.org/dc/terms/> .
+
+ogit:altitude
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "altitude";
+	dcterms:description """Altitude is a distance measurement, usually in the vertical direction, in relation to a reference point or object.""";
+	dcterms:valid "start=2025-10-15;";
+	dcterms:creator "Markus Noack";
+.


### PR DESCRIPTION
Adds SGO attribute "altitude" and NTO node "WeatherStation".

The "WeatherStation" represents a physical weather observation site used as a basis on connecting Timeseries weather data points.
"Altitude" is an attribute that can be used to describe for example the elevation of WeatherStations above sea level. This is an important to know when comparing weather data across stations.