### PR TITLE
add optional attribute "type" to "Location"

### DIFF
--- a/SGO/sgo/entities/Location.ttl
+++ b/SGO/sgo/entities/Location.ttl
@@ -33,6 +33,7 @@ Organization. Similar to http://purl.org/goodrelations/v1#Location""";
 		ogit:longitude
 		ogit:latitude
 		ogit:altitude
+		ogit:type
 	);
 	ogit:indexed-attributes (
 		


### PR DESCRIPTION
The optional attribute "type" on "Location" can be used (similar to "Region") to define the type of Location we are dealing with. This could be useful when thinking of a locations as POIs with types of "Weather Station" / "Shopping Center" / "Gas Station" etc.