### PR TITLE
feat(Person): allow ogit:locatedIn to ogit.Location:Address

### DIFF
--- a/SGO/sgo/entities/Person.ttl
+++ b/SGO/sgo/entities/Person.ttl
@@ -306,6 +306,7 @@ ogit:Person
 
 			# Geographic anchors
 			[ ogit:locatedIn      ogit:Region ]
+			[ ogit:locatedIn      ogit.Location:Address ]
 			[ ogit:hasNationality ogit:Region ]
 			[ ogit:bornIn         ogit:Region ]
 			[ ogit:residesIn      ogit:Region ]


### PR DESCRIPTION
Symmetric fix for the OSINT Security Extension PR. Organization.ttl already has [ ogit:locatedIn ogit.Location:Address ] (line 174); the matching entry was missing on Person.ttl.

Without this, Person -> Address edges via ogit:locatedIn are rejected by the TTL validator with the error

  edge type ogit/locatedIn is not defined for
  out-vertex type ogit/Person and
  in-vertex type ogit/Location/Address

Discovered while bulk-loading the ICIJ Offshore Leaks 2025-03-31 dataset into the OSINT graph: ICIJ encodes "registered_address" relations between officers (Persons) and address vertices, and 508,845 such edges were rejected on the cluster.

After this change Person can be located at an Address node, which matches the OSINT use case and keeps Person.ttl consistent with Organization.ttl.

### Important Note:

It is recommended **NOT** to merge pull requests on weekends.
