### PR TITLE
NTO/GFS: add Bardioc Graph File System namespace (5 entities, 2 verbs, 17 attributes)

### DIFF
--- a/NTO/GFS/README.md
+++ b/NTO/GFS/README.md
@@ -1,0 +1,47 @@
+# GFS
+
+## Overview
+
+This is a graph system NTO governing the **Bardioc Graph File
+System (GFS)** -- a platform-level filesystem in which files,
+folders, symbolic links, sharing tokens, and file-type-to-app
+mappings are first-class graph constructs. Bytes live in the
+platform object store; metadata, permissions, and audit live
+in the graph.
+
+## Contents
+
+| Folder | What it holds |
+|---|---|
+| `entities/` | Five vertex types: `File`, `Folder`, `Symlink`, `ShareLink`, `AppHandler`. Each derives from `ogit:Entity`; none are subclasses of an existing OGIT type. |
+| `verbs/` | Two new edges: `refersTo` (Symlink to target), `sharedVia` (File or Folder to ShareLink). Containment (`ogit:contains`) and team membership (`ogit.Auth:isMemberOf`) are reused unchanged. |
+| `attributes/` | Seventeen new properties covering MIME, content-pointers (via standard OGIT attributes), per-device restrictions, the ShareLink token, the AppHandler mapping fields, and soft-delete markers. |
+
+## Permission model
+
+Permissions are not modelled here. They reuse the platform's
+existing scope, role-rule, and ACL-materialisation mechanisms.
+The platform materialisation pipeline maintains two reserved
+properties on every GFS vertex -- `_effectiveReaders` and
+`_effectiveDevices` -- which the platform owns and which are
+not part of the `ogit.GFS:` namespace.
+
+## Related platform extensions
+
+GFS depends on three constructs that live outside `NTO/GFS/`
+and ship as separate platform-team contributions (coordinated
+with the OGIT review):
+
+- `ogit.Auth:Device` -- end-user device vertex carrying a
+  `securityLevel` 0-100.
+- `ogit.Auth:usesDevice` -- Account-to-Device, many-to-many.
+- `ogit:hasVault` -- Person-to-DataScope anchor for Personal
+  Vaults (location open: `SGO/sgo/verbs/` or `NTO/Auth/verbs/`).
+- A Workspace marker (boolean attribute) on `ogit.Auth:Team`.
+
+## Audit
+
+GFS does not introduce an `AuditEvent` vertex. Audit is a
+platform concern; GFS emits events through the existing
+platform `AuditEventListenerRegistry`. A consolidated platform
+audit concept is tracked separately.

--- a/NTO/GFS/attributes/allowedEmails.ttl
+++ b/NTO/GFS/attributes/allowedEmails.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:allowedEmails
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "allowedEmails";
+    dcterms:description "Optional list of allowed recipient email addresses on a ShareLink. When set, the Public-Share-WebService requires the recipient to verify via Email-OTP before granting access.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/appId.ttl
+++ b/NTO/GFS/attributes/appId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:appId
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "appId";
+    dcterms:description "Bardioc app identifier as referenced by the FileExplorer when invoking 'Open with'.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/archivedAt.ttl
+++ b/NTO/GFS/attributes/archivedAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:archivedAt
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "archivedAt";
+    dcterms:description "Soft-delete marker on File, Folder, or Symlink. When set, the vertex is hidden from default listings but remains in the graph for audit and possible restore.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/capability.ttl
+++ b/NTO/GFS/attributes/capability.ttl
@@ -11,4 +11,6 @@ ogit.GFS:capability
     dcterms:description "Capability set as a vertex property on ogit.GFS:ShareLink. Subset of: read, write, share, admin, delete. Drives what the token holder is allowed to do via the public-share gateway. Bardioc edges cannot carry attributes, so capability lives on the ShareLink vertex, not on any edge.";
     dcterms:valid "start=2026-05-21;";
     dcterms:creator "Almato AG";
+    ogit:validation-parameter "read,write,share,admin,delete";
+    ogit:validation-type "fixed";
 .

--- a/NTO/GFS/attributes/capability.ttl
+++ b/NTO/GFS/attributes/capability.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:capability
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "capability";
+    dcterms:description "Capability set as a vertex property on ogit.GFS:ShareLink. Subset of: read, write, share, admin, delete. Drives what the token holder is allowed to do via the public-share gateway. Bardioc edges cannot carry attributes, so capability lives on the ShareLink vertex, not on any edge.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/expiresAt.ttl
+++ b/NTO/GFS/attributes/expiresAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:expiresAt
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "expiresAt";
+    dcterms:description "ISO timestamp at which a ShareLink expires. After this point, the Public-Share-WebService denies all requests carrying the token.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/inheritPermissions.ttl
+++ b/NTO/GFS/attributes/inheritPermissions.ttl
@@ -11,4 +11,6 @@ ogit.GFS:inheritPermissions
     dcterms:description "Boolean flag on Folder. When true, the platform permission materialisation pipeline walks up the parent chain to compute effective permissions. When false, only this folder's and its descendants' explicit permissions count (Replace semantics, NTFS-style).";
     dcterms:valid "start=2026-05-21;";
     dcterms:creator "Almato AG";
+    ogit:validation-parameter "true,false";
+    ogit:validation-type "fixed";
 .

--- a/NTO/GFS/attributes/inheritPermissions.ttl
+++ b/NTO/GFS/attributes/inheritPermissions.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:inheritPermissions
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "inheritPermissions";
+    dcterms:description "Boolean flag on Folder. When true, the platform permission materialisation pipeline walks up the parent chain to compute effective permissions. When false, only this folder's and its descendants' explicit permissions count (Replace semantics, NTFS-style).";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/maxUses.ttl
+++ b/NTO/GFS/attributes/maxUses.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:maxUses
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "maxUses";
+    dcterms:description "Optional maximum number of times a ShareLink can be successfully resolved before it self-revokes.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/mimePattern.ttl
+++ b/NTO/GFS/attributes/mimePattern.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:mimePattern
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "mimePattern";
+    dcterms:description "MIME pattern at ogit.GFS:AppHandler. Exact MIME or wildcard form (e.g. 'image/*').";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/mimeType.ttl
+++ b/NTO/GFS/attributes/mimeType.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:mimeType
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "mimeType";
+    dcterms:description "MIME type of a file (RFC 6838). On ogit.GFS:File this is mandatory and drives the FileType-to-App resolution.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/minDeviceSecurityLevel.ttl
+++ b/NTO/GFS/attributes/minDeviceSecurityLevel.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:minDeviceSecurityLevel
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "minDeviceSecurityLevel";
+    dcterms:description "Optional integer property on File or Folder. The accessing ogit.Auth:Device must have a securityLevel greater than or equal to this value. Set on a Folder, the value applies to every File reached through that Folder's contains-chain (subject to inheritPermissions). Materialised into the platform-maintained _effectiveDevices property on each File.";
+    dcterms:valid "start=2026-05-22;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/priority.ttl
+++ b/NTO/GFS/attributes/priority.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:priority
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "priority";
+    dcterms:description "Integer priority for AppHandler resolution. Lower values are preferred.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/restrictToDevices.ttl
+++ b/NTO/GFS/attributes/restrictToDevices.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:restrictToDevices
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "restrictToDevices";
+    dcterms:description "Optional multi-value list of ogit.Auth:Device IDs on File or Folder. When set, only the listed devices may render the file (or any File reached through this Folder's contains-chain, subject to inheritPermissions). Materialised into the platform-maintained _effectiveDevices property on each File.";
+    dcterms:valid "start=2026-05-22;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/revokedAt.ttl
+++ b/NTO/GFS/attributes/revokedAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:revokedAt
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "revokedAt";
+    dcterms:description "Timestamp set when a ShareLink is explicitly revoked. After this point, the Public-Share-WebService denies all requests carrying the token, regardless of expiresAt.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/scopeRef.ttl
+++ b/NTO/GFS/attributes/scopeRef.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:scopeRef
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "scopeRef";
+    dcterms:description "Optional reference to a Workspace or DataScope ID that restricts an AppHandler's applicability. When empty, the mapping is global.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/token.ttl
+++ b/NTO/GFS/attributes/token.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:token
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "token";
+    dcterms:description "Opaque, cryptographically random token on a ShareLink. Indexed so the Public-Share-WebService can look up the ShareLink by token quickly.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/usedCount.ttl
+++ b/NTO/GFS/attributes/usedCount.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:usedCount
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "usedCount";
+    dcterms:description "Counter of successful resolutions for a ShareLink. Incremented atomically by the Public-Share-WebService on each accepted request.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/vaultRoot.ttl
+++ b/NTO/GFS/attributes/vaultRoot.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:vaultRoot
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "vaultRoot";
+    dcterms:description "Boolean marker on Folder. When true, this folder is the user-facing root of a Vault DataScope (Personal Vault or Team Vault). Exactly one such folder exists per Vault scope.";
+    dcterms:valid "start=2026-05-22;";
+    dcterms:creator "Almato AG";
+.

--- a/NTO/GFS/attributes/vaultRoot.ttl
+++ b/NTO/GFS/attributes/vaultRoot.ttl
@@ -11,4 +11,6 @@ ogit.GFS:vaultRoot
     dcterms:description "Boolean marker on Folder. When true, this folder is the user-facing root of a Vault DataScope (Personal Vault or Team Vault). Exactly one such folder exists per Vault scope.";
     dcterms:valid "start=2026-05-22;";
     dcterms:creator "Almato AG";
+    ogit:validation-parameter "true,false";
+    ogit:validation-type "fixed";
 .

--- a/NTO/GFS/entities/AppHandler.ttl
+++ b/NTO/GFS/entities/AppHandler.ttl
@@ -4,12 +4,11 @@
 @prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 
-# ogit.GFS:AppHandler -- MIME-zu-Bardioc-App-Mapping fuer "Open-with"-
-# Verhalten im FileExplorer.
-# v0.2 (post Round-1 reviewer feedback).
+# ogit.GFS:AppHandler -- MIME-pattern to Bardioc-app mapping for
+# the FileExplorer "Open with" behaviour.
 #
-# Default-Mappings beim Bardioc-Bootstrap installiert. Pro Workspace
-# oder pro User koennen Overrides via scopeRef gesetzt werden.
+# Default mappings are installed at Bardioc bootstrap. Per-workspace
+# or per-user overrides can be set via scopeRef.
 
 ogit.GFS:AppHandler
     a rdfs:Class;
@@ -19,7 +18,7 @@ ogit.GFS:AppHandler
     dcterms:valid "start=2026-05-21;";
     dcterms:creator "Almato AG";
     dcterms:created "2026-05-21";
-    dcterms:modified "2026-05-28";
+    dcterms:modified "2026-05-29";
     ogit:admin-contact "Almato AG";
     ogit:tech-contact "Almato AG";
     ogit:scope "NTO";

--- a/NTO/GFS/entities/AppHandler.ttl
+++ b/NTO/GFS/entities/AppHandler.ttl
@@ -1,0 +1,44 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+# ogit.GFS:AppHandler -- MIME-zu-Bardioc-App-Mapping fuer "Open-with"-
+# Verhalten im FileExplorer.
+# v0.2 (post Round-1 reviewer feedback).
+#
+# Default-Mappings beim Bardioc-Bootstrap installiert. Pro Workspace
+# oder pro User koennen Overrides via scopeRef gesetzt werden.
+
+ogit.GFS:AppHandler
+    a rdfs:Class;
+    rdfs:subClassOf ogit:Entity;
+    rdfs:label "AppHandler";
+    dcterms:description "Maps a MIME type or MIME pattern to a Bardioc app. The FileExplorer queries this registry to decide which app should open a given file when the user clicks 'Open'. Lower priority value means higher preference. Optional scopeRef restricts a mapping to a Workspace or DataScope.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+    dcterms:created "2026-05-21";
+    dcterms:modified "2026-05-28";
+    ogit:admin-contact "Almato AG";
+    ogit:tech-contact "Almato AG";
+    ogit:scope "NTO";
+    ogit:parent ogit:Node;
+    ogit:blob "false";
+    ogit:mandatory-attributes (
+        ogit.GFS:mimePattern
+        ogit.GFS:appId
+        ogit.GFS:priority
+    );
+    ogit:optional-attributes (
+        ogit.GFS:scopeRef
+    );
+    ogit:indexed-attributes (
+        ogit.GFS:mimePattern
+        ogit.GFS:scopeRef
+    );
+    ogit:history (
+    );
+    ogit:allowed (
+    );
+.

--- a/NTO/GFS/entities/File.ttl
+++ b/NTO/GFS/entities/File.ttl
@@ -4,16 +4,15 @@
 @prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 
-# ogit.GFS:File -- Filesystem-Datei im Bardioc Graph File System.
-# v0.2 (post Round-1 reviewer feedback).
+# ogit.GFS:File -- filesystem file in the Bardioc Graph File System.
 #
-# Bytes liegen im Object-Store hinter der Graph-API
-# (BlobStorageProvider). Der Vertex haelt Metadaten, optional
-# Per-Device-Restriktionen, und wird per ogit:contains in einen
-# Folder gehaengt. Permissions werden ueber die platform-
-# maintained Properties _effectiveReaders und _effectiveDevices
-# materialisiert (nicht in dieser TTL definiert; sie leben im
-# Plattform-reservierten Namespace analog zu ogit/_acl).
+# Bytes live in the object store behind the platform graph API
+# (BlobStorageProvider). The vertex carries metadata, optional
+# per-device restrictions, and is placed under a Folder via
+# ogit:contains. Permissions are materialised by the platform
+# pipeline into the platform-reserved properties _effectiveReaders
+# and _effectiveDevices (not defined here; they live in the
+# platform-reserved namespace alongside ogit/_acl).
 
 ogit.GFS:File
     a rdfs:Class;
@@ -23,7 +22,7 @@ ogit.GFS:File
     dcterms:valid "start=2026-05-21;";
     dcterms:creator "Almato AG";
     dcterms:created "2026-05-21";
-    dcterms:modified "2026-05-28";
+    dcterms:modified "2026-05-29";
     ogit:admin-contact "Almato AG";
     ogit:tech-contact "Almato AG";
     ogit:scope "NTO";

--- a/NTO/GFS/entities/File.ttl
+++ b/NTO/GFS/entities/File.ttl
@@ -1,0 +1,52 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+# ogit.GFS:File -- Filesystem-Datei im Bardioc Graph File System.
+# v0.2 (post Round-1 reviewer feedback).
+#
+# Bytes liegen im Object-Store hinter der Graph-API
+# (BlobStorageProvider). Der Vertex haelt Metadaten, optional
+# Per-Device-Restriktionen, und wird per ogit:contains in einen
+# Folder gehaengt. Permissions werden ueber die platform-
+# maintained Properties _effectiveReaders und _effectiveDevices
+# materialisiert (nicht in dieser TTL definiert; sie leben im
+# Plattform-reservierten Namespace analog zu ogit/_acl).
+
+ogit.GFS:File
+    a rdfs:Class;
+    rdfs:subClassOf ogit:Entity;
+    rdfs:label "File";
+    dcterms:description "A filesystem file in the Bardioc Graph File System (GFS). Bytes are stored in the platform object store via the existing BlobStorageProvider mechanism; this vertex holds metadata, optional per-device restrictions, and folder placement. Permissions on the file are materialised by the platform pipeline into _effectiveReaders and _effectiveDevices, not modelled here.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+    dcterms:created "2026-05-21";
+    dcterms:modified "2026-05-28";
+    ogit:admin-contact "Almato AG";
+    ogit:tech-contact "Almato AG";
+    ogit:scope "NTO";
+    ogit:parent ogit:Node;
+    ogit:blob "true";
+    ogit:mandatory-attributes (
+        ogit:name
+        ogit.GFS:mimeType
+    );
+    ogit:optional-attributes (
+        ogit:size
+        ogit:version
+        ogit.GFS:minDeviceSecurityLevel
+        ogit.GFS:restrictToDevices
+        ogit.GFS:archivedAt
+    );
+    ogit:indexed-attributes (
+        ogit:name
+        ogit.GFS:mimeType
+    );
+    ogit:history (
+    );
+    ogit:allowed (
+        [ ogit.GFS:sharedVia  ogit.GFS:ShareLink ]
+    );
+.

--- a/NTO/GFS/entities/Folder.ttl
+++ b/NTO/GFS/entities/Folder.ttl
@@ -1,0 +1,54 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+# ogit.GFS:Folder -- Container fuer FS-Children im Bardioc GFS.
+# v0.2 (post Round-1 reviewer feedback).
+#
+# Verwendet das bestehende ogit:contains Verb. In der GFS-Sicht
+# ist die Containment-Beziehung single-parent (Sharing erfolgt
+# nicht durch Multi-Parent-Mount, sondern durch Vertex-Kopie in
+# den Ziel-DataScope plus ACL-Erweiterung im selben Scope).
+#
+# Ein Folder mit vaultRoot=true ist der user-facing Wurzel-
+# Folder eines Vault-DataScope; Default-Name "My Files Protected".
+
+ogit.GFS:Folder
+    a rdfs:Class;
+    rdfs:subClassOf ogit:Entity;
+    rdfs:label "Folder";
+    dcterms:description "A container vertex in the Bardioc Graph File System. Holds child vertices via the reused ogit:contains verb. In the GFS view containment is single-parent. A folder with vaultRoot=true (default false) is the user-facing root of a Vault DataScope.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+    dcterms:created "2026-05-21";
+    dcterms:modified "2026-05-28";
+    ogit:admin-contact "Almato AG";
+    ogit:tech-contact "Almato AG";
+    ogit:scope "NTO";
+    ogit:parent ogit:Node;
+    ogit:blob "false";
+    ogit:mandatory-attributes (
+        ogit:name
+        ogit.GFS:inheritPermissions
+    );
+    ogit:optional-attributes (
+        ogit.GFS:vaultRoot
+        ogit.GFS:minDeviceSecurityLevel
+        ogit.GFS:restrictToDevices
+        ogit.GFS:archivedAt
+    );
+    ogit:indexed-attributes (
+        ogit:name
+        ogit.GFS:vaultRoot
+    );
+    ogit:history (
+    );
+    ogit:allowed (
+        [ ogit:contains       ogit.GFS:File ]
+        [ ogit:contains       ogit.GFS:Folder ]
+        [ ogit:contains       ogit.GFS:Symlink ]
+        [ ogit.GFS:sharedVia  ogit.GFS:ShareLink ]
+    );
+.

--- a/NTO/GFS/entities/Folder.ttl
+++ b/NTO/GFS/entities/Folder.ttl
@@ -4,16 +4,15 @@
 @prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 
-# ogit.GFS:Folder -- Container fuer FS-Children im Bardioc GFS.
-# v0.2 (post Round-1 reviewer feedback).
+# ogit.GFS:Folder -- container vertex for filesystem children.
 #
-# Verwendet das bestehende ogit:contains Verb. In der GFS-Sicht
-# ist die Containment-Beziehung single-parent (Sharing erfolgt
-# nicht durch Multi-Parent-Mount, sondern durch Vertex-Kopie in
-# den Ziel-DataScope plus ACL-Erweiterung im selben Scope).
+# Uses the existing ogit:contains verb. In the GFS view, the
+# containment relation is single-parent: sharing is done by
+# vertex-copy into the target DataScope plus ACL extension
+# within the same scope, not by multi-parent mount.
 #
-# Ein Folder mit vaultRoot=true ist der user-facing Wurzel-
-# Folder eines Vault-DataScope; Default-Name "My Files Protected".
+# A folder with vaultRoot=true is the user-facing root folder
+# of a Vault DataScope; default name "My Files Protected".
 
 ogit.GFS:Folder
     a rdfs:Class;
@@ -23,7 +22,7 @@ ogit.GFS:Folder
     dcterms:valid "start=2026-05-21;";
     dcterms:creator "Almato AG";
     dcterms:created "2026-05-21";
-    dcterms:modified "2026-05-28";
+    dcterms:modified "2026-05-29";
     ogit:admin-contact "Almato AG";
     ogit:tech-contact "Almato AG";
     ogit:scope "NTO";

--- a/NTO/GFS/entities/ShareLink.ttl
+++ b/NTO/GFS/entities/ShareLink.ttl
@@ -1,0 +1,51 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+# ogit.GFS:ShareLink -- Capability-Token-Vertex im Bardioc GFS.
+# v0.2 (post Round-1 reviewer feedback).
+#
+# Lebt im DataScope des Sharers, damit Audit, Revocation und
+# Listing trivial moeglich sind. Token-Property ist indexiert,
+# damit der Public-Share-WebService schnell aufloesen kann.
+#
+# Hinweis zu capability: in v0.2 ist capability eine Vertex-
+# Property an der ShareLink (nicht eine Edge-Property an einer
+# grants-Edge, weil Bardioc-Edges keine Attribute tragen).
+
+ogit.GFS:ShareLink
+    a rdfs:Class;
+    rdfs:subClassOf ogit:Entity;
+    rdfs:label "ShareLink";
+    dcterms:description "A capability-bearing token vertex in the Bardioc Graph File System. Used by the Public-Share-WebService to expose a File or Folder to non-Bardioc recipients via an opaque URL. The capability set is a vertex property on this ShareLink, not on any edge.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+    dcterms:created "2026-05-21";
+    dcterms:modified "2026-05-28";
+    ogit:admin-contact "Almato AG";
+    ogit:tech-contact "Almato AG";
+    ogit:scope "NTO";
+    ogit:parent ogit:Node;
+    ogit:blob "false";
+    ogit:mandatory-attributes (
+        ogit.GFS:token
+        ogit.GFS:capability
+        ogit.GFS:expiresAt
+    );
+    ogit:optional-attributes (
+        ogit.GFS:maxUses
+        ogit.GFS:usedCount
+        ogit.GFS:allowedEmails
+        ogit.GFS:revokedAt
+    );
+    ogit:indexed-attributes (
+        ogit.GFS:token
+        ogit.GFS:expiresAt
+    );
+    ogit:history (
+    );
+    ogit:allowed (
+    );
+.

--- a/NTO/GFS/entities/ShareLink.ttl
+++ b/NTO/GFS/entities/ShareLink.ttl
@@ -4,16 +4,14 @@
 @prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 
-# ogit.GFS:ShareLink -- Capability-Token-Vertex im Bardioc GFS.
-# v0.2 (post Round-1 reviewer feedback).
+# ogit.GFS:ShareLink -- capability-bearing token vertex.
 #
-# Lebt im DataScope des Sharers, damit Audit, Revocation und
-# Listing trivial moeglich sind. Token-Property ist indexiert,
-# damit der Public-Share-WebService schnell aufloesen kann.
+# Lives in the sharer's DataScope so that audit, revocation and
+# listing are trivial. The token property is indexed so the
+# public-share web service can resolve a token in constant time.
 #
-# Hinweis zu capability: in v0.2 ist capability eine Vertex-
-# Property an der ShareLink (nicht eine Edge-Property an einer
-# grants-Edge, weil Bardioc-Edges keine Attribute tragen).
+# Capability set is a vertex-property on the ShareLink (not an
+# edge attribute, because Bardioc edges cannot carry attributes).
 
 ogit.GFS:ShareLink
     a rdfs:Class;
@@ -23,7 +21,7 @@ ogit.GFS:ShareLink
     dcterms:valid "start=2026-05-21;";
     dcterms:creator "Almato AG";
     dcterms:created "2026-05-21";
-    dcterms:modified "2026-05-28";
+    dcterms:modified "2026-05-29";
     ogit:admin-contact "Almato AG";
     ogit:tech-contact "Almato AG";
     ogit:scope "NTO";

--- a/NTO/GFS/entities/Symlink.ttl
+++ b/NTO/GFS/entities/Symlink.ttl
@@ -1,0 +1,42 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+# ogit.GFS:Symlink -- Verweis-Vertex im Bardioc GFS.
+# v0.2 (post Round-1 reviewer feedback).
+#
+# Permission-Pruefung erfolgt am Ziel (refersTo-Target), nicht am
+# Symlink. Der Symlink selbst braucht nur read in der Pfad-
+# Resolution, um in Folder-Listings zu erscheinen.
+
+ogit.GFS:Symlink
+    a rdfs:Class;
+    rdfs:subClassOf ogit:Entity;
+    rdfs:label "Symlink";
+    dcterms:description "A symbolic link in the Bardioc Graph File System. Refers to an arbitrary target vertex via ogit.GFS:refersTo. Cycle protection: maximum resolution hop depth is enforced by the GFS-API (default 16).";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+    dcterms:created "2026-05-21";
+    dcterms:modified "2026-05-28";
+    ogit:admin-contact "Almato AG";
+    ogit:tech-contact "Almato AG";
+    ogit:scope "NTO";
+    ogit:parent ogit:Node;
+    ogit:blob "false";
+    ogit:mandatory-attributes (
+        ogit:name
+    );
+    ogit:optional-attributes (
+        ogit.GFS:archivedAt
+    );
+    ogit:indexed-attributes (
+        ogit:name
+    );
+    ogit:history (
+    );
+    ogit:allowed (
+        [ ogit.GFS:refersTo  ogit:Entity ]
+    );
+.

--- a/NTO/GFS/entities/Symlink.ttl
+++ b/NTO/GFS/entities/Symlink.ttl
@@ -4,12 +4,11 @@
 @prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 
-# ogit.GFS:Symlink -- Verweis-Vertex im Bardioc GFS.
-# v0.2 (post Round-1 reviewer feedback).
+# ogit.GFS:Symlink -- reference vertex in the Bardioc GFS.
 #
-# Permission-Pruefung erfolgt am Ziel (refersTo-Target), nicht am
-# Symlink. Der Symlink selbst braucht nur read in der Pfad-
-# Resolution, um in Folder-Listings zu erscheinen.
+# Permission check is evaluated on the refersTo-target, not on
+# the symlink itself. The symlink only needs read permission
+# during path resolution to appear in folder listings.
 
 ogit.GFS:Symlink
     a rdfs:Class;
@@ -19,7 +18,7 @@ ogit.GFS:Symlink
     dcterms:valid "start=2026-05-21;";
     dcterms:creator "Almato AG";
     dcterms:created "2026-05-21";
-    dcterms:modified "2026-05-28";
+    dcterms:modified "2026-05-29";
     ogit:admin-contact "Almato AG";
     ogit:tech-contact "Almato AG";
     ogit:scope "NTO";

--- a/NTO/GFS/entities/Symlink.ttl
+++ b/NTO/GFS/entities/Symlink.ttl
@@ -37,6 +37,8 @@ ogit.GFS:Symlink
     ogit:history (
     );
     ogit:allowed (
-        [ ogit.GFS:refersTo  ogit:Entity ]
+        [ ogit.GFS:refersTo  ogit.GFS:File ]
+        [ ogit.GFS:refersTo  ogit.GFS:Folder ]
+        [ ogit.GFS:refersTo  ogit.GFS:Symlink ]
     );
 .

--- a/NTO/GFS/verbs/refersTo.ttl
+++ b/NTO/GFS/verbs/refersTo.ttl
@@ -12,7 +12,7 @@ ogit.GFS:refersTo
     dcterms:valid "start=2026-05-21;";
     dcterms:creator "Almato AG";
     dcterms:created "2026-05-21";
-    dcterms:modified "2026-05-28";
+    dcterms:modified "2026-05-29";
     ogit:admin-contact "Almato AG";
     ogit:tech-contact "Almato AG";
     ogit:history (

--- a/NTO/GFS/verbs/refersTo.ttl
+++ b/NTO/GFS/verbs/refersTo.ttl
@@ -1,0 +1,20 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:refersTo
+    a owl:ObjectProperty;
+    rdfs:subPropertyOf ogit:Verb;
+    rdfs:label "refersTo";
+    dcterms:description "Symlink-to-target reference in the GFS. Resolution is lazy; the GFS-API enforces a maximum hop depth (default 16) to prevent symlink loops.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+    dcterms:created "2026-05-21";
+    dcterms:modified "2026-05-28";
+    ogit:admin-contact "Almato AG";
+    ogit:tech-contact "Almato AG";
+    ogit:history (
+    );
+.

--- a/NTO/GFS/verbs/sharedVia.ttl
+++ b/NTO/GFS/verbs/sharedVia.ttl
@@ -12,7 +12,7 @@ ogit.GFS:sharedVia
     dcterms:valid "start=2026-05-21;";
     dcterms:creator "Almato AG";
     dcterms:created "2026-05-21";
-    dcterms:modified "2026-05-28";
+    dcterms:modified "2026-05-29";
     ogit:admin-contact "Almato AG";
     ogit:tech-contact "Almato AG";
     ogit:history (

--- a/NTO/GFS/verbs/sharedVia.ttl
+++ b/NTO/GFS/verbs/sharedVia.ttl
@@ -1,0 +1,20 @@
+@prefix ogit:           <http://www.purl.org/ogit/> .
+@prefix ogit.GFS:       <http://www.purl.org/ogit/GFS/> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+
+ogit.GFS:sharedVia
+    a owl:ObjectProperty;
+    rdfs:subPropertyOf ogit:Verb;
+    rdfs:label "sharedVia";
+    dcterms:description "Links a File or Folder to a ShareLink vertex. One source vertex can have multiple ShareLinks for different recipients or capability levels.";
+    dcterms:valid "start=2026-05-21;";
+    dcterms:creator "Almato AG";
+    dcterms:created "2026-05-21";
+    dcterms:modified "2026-05-28";
+    ogit:admin-contact "Almato AG";
+    ogit:tech-contact "Almato AG";
+    ogit:history (
+    );
+.


### PR DESCRIPTION
## Summary

This PR adds a new `ogit.GFS:` sub-namespace under `NTO/GFS/`
for the Bardioc Graph File System (GFS) -- a platform-level
filesystem that turns files, folders, symbolic links, sharing
tokens, and file-type-to-app mappings into first-class graph
constructs. Permissions and sharing are expressed through the
platform's existing scope, role-rule, and ACL-materialisation
mechanisms; this PR introduces no parallel permission layer.

The diff is intentionally minimal: five new entities, two new
verbs, seventeen new attributes. Two existing constructs
(`ogit:contains`, `ogit.Auth:isMemberOf`) are reused unchanged.

## What is added

### Entities (`NTO/GFS/entities/`)

| Type | Purpose |
|---|---|
| `ogit.GFS:File` | Filesystem file; mandatory MIME plus content-pointer; `blob=true` |
| `ogit.GFS:Folder` | Container vertex; reuses `ogit:contains`; `inheritPermissions` toggle; optional `vaultRoot` marker |
| `ogit.GFS:Symlink` | Reference vertex with one outgoing `refersTo` edge |
| `ogit.GFS:ShareLink` | Capability-bearing token vertex for non-Bardioc recipients; `token` indexed |
| `ogit.GFS:AppHandler` | MIME-pattern-to-Bardioc-app mapping |

### Verbs (`NTO/GFS/verbs/`)

| Verb | From | To | Purpose |
|---|---|---|---|
| `ogit.GFS:refersTo` | Symlink | `ogit:Entity` (type-agnostic) | Symlink target; 16-hop max resolution |
| `ogit.GFS:sharedVia` | File, Folder | ShareLink | external sharing |

### Attributes (`NTO/GFS/attributes/`)

Seventeen new attributes: `mimeType`, `inheritPermissions`,
`vaultRoot`, `minDeviceSecurityLevel`, `restrictToDevices`,
`mimePattern`, `appId`, `priority`, `scopeRef`, `capability`,
`token`, `expiresAt`, `maxUses`, `usedCount`, `allowedEmails`,
`revokedAt`, `archivedAt`. See each TTL for the per-property
description.

`capability` is a vertex-property on `ShareLink` (not an edge
attribute -- Bardioc edges cannot carry attributes). The five
recognised capability values are `read`, `write`, `share`,
`admin`, `delete`.

`minDeviceSecurityLevel` and `restrictToDevices` are defined
on both `File` and `Folder`. Folder-level usage is inherited
by every File reached through the Folder's `ogit:contains`-chain
(subject to `inheritPermissions`).

## What is NOT in this PR

### Platform-reserved materialised ACL attributes

The platform materialisation pipeline maintains two attributes
on every GFS vertex that are not part of this diff:

- `_effectiveReaders` -- multi-value Account-and-Team IDs,
  indexed; lists who may read.
- `_effectiveDevices` -- multi-value Device IDs, indexed; lists
  which devices may render.

These attributes belong in the platform-reserved namespace
(alongside `ogit/_acl`), not in `ogit.GFS:`, because the
maintaining party is the platform's materialisation pipeline,
not the GFS sub-system. Their exact naming is one of the open
issues below.

### Platform extensions in `NTO/Auth/` and `SGO/sgo/`

Four constructs outside `NTO/GFS/` are needed for GFS to
function but ship in a separate platform-team PR, coordinated
with the OGIT review:

- `ogit.Auth:Device` (new entity in `NTO/Auth/entities/`) --
  end-user-device vertex with `securityLevel` 0-100. Distinct
  from the SGO datacenter-equipment `ogit:Device`.
- `ogit.Auth:usesDevice` (new verb in `NTO/Auth/verbs/`) --
  Account-to-Device, many-to-many.
- `ogit:hasVault` (new verb, location open: `SGO/sgo/verbs/` or
  `NTO/Auth/verbs/`) -- Person-to-DataScope, anchors a Personal
  Vault to a Person so it survives Account deactivation.
- Workspace marker on `ogit.Auth:Team` -- new optional boolean
  attribute signalling "self-service Workspace, members manage
  themselves, has its own DataScope".

### Audit events

GFS does not introduce an `AuditEvent` vertex type. Audit is a
platform-level concern and a separate consolidation project;
GFS commits to emitting audit-relevant events through the
existing platform `AuditEventListenerRegistry`.

## Open issues for the OGIT review

Three points where the GFS team has chosen a direction but
wants the OGIT review to ratify or redirect.

**Issue 1 -- Namespace of the materialised ACL attributes.**
The diff proposes `ogit/_effectiveReaders` and
`ogit/_effectiveDevices` in the platform-reserved namespace
alongside `ogit/_acl`. They could equivalently live in
`ogit.GFS:` if the OGIT review prefers ownership symmetry. The
working assumption is that the maintaining party (the
platform's materialisation pipeline) owns the namespace, not
the consuming sub-system.

**Issue 2 -- `vaultRoot` as property or subtype.** This PR
carries `vaultRoot` as a boolean attribute on `Folder`. An
alternative is a small `ogit.GFS:VaultRootFolder` subtype. The
property path keeps the diff smaller; the subtype path is
semantically cleaner. OGIT-review preference welcome.

**Issue 3 -- Capability vocabulary persistence.** The five-
capability vocabulary (`read`, `write`, `share`, `admin`,
`delete`) lives only as constraint metadata on the ShareLink
`capability` attribute and as semantic vocabulary in the GFS
documentation. The OGIT review may want a formal capability
enumeration entity. The working assumption is no; a documented
string set is sufficient.

## Owner-string convention question

These are the first new OGIT entities authored under Almato AG
(post arago-Almato merger). All seven new TTL types carry
`dcterms:creator "Almato AG"` plus `ogit:admin-contact` /
`ogit:tech-contact "Almato AG"` on the entity and verb files.
We assume this is the correct owner string going forward; please
flag if the OGIT convention requires `arago GmbH` as historical
owner-string constancy -- mechanical replace if so.

## Diff stats

- 24 new TTL files under `NTO/GFS/`: 5 entities, 2 verbs, 17
  attributes.
- 0 files modified outside `NTO/GFS/`.
- All 24 files validate cleanly with `rdflib` 7.6.0
  (turtle parse).
- Total new triples added across the 24 files: roughly 280.

## Companion concept document

The full concept that motivates this ontology lives at
`bardioc_gfs/_concept/01_overall_concept.md` (Overall Concept)
and `bardioc_gfs/_concept/02_ogit_extensions.md` (this PR's
narrative). A reviewer-friendly Word build of both lives in
the Bardioc Product Management Dropbox under
`Bardioc GFS/Reviewable Deliverables/`. Six reviewer passes
(Viktor R1+R2, Thommy R1, Patrick R1+R2, Cy R1+follow-ups) are
recorded in the change-log appendix of the Word documents.
