### PR TITLE
NTO/Integration: Bardioc Connector Framework 2.0 schema

### DIFF
--- a/NTO/Integration/Decisions/Audit/README.md
+++ b/NTO/Integration/Decisions/Audit/README.md
@@ -1,0 +1,20 @@
+# Integration / Decisions / Audit
+
+## Overview
+
+Audit-and-evidence records that MUST survive Right-to-Erasure. Vertices here
+reference subjects only by stable pseudonymous identifiers that survive erasure;
+they carry no raw PII.
+
+Entities: ActionInvocation, ValueDriftCandidate, SchemaDriftCandidate.
+
+- Right-to-Erasure operations MUST NOT touch this namespace.
+- A record derived from a Subject's PII (e.g. a drift candidate's unrecognised
+  payload, or a source id) MUST be pseudonymised before persistence -- the
+  survive-erasure guarantee is on the structural record, not on raw source
+  content.
+
+**Audit-forever applies to streams, not vertices.** ActionInvocation is
+ephemeral (hard-deleted after its terminal state); the audit guarantee is on the
+timeseries / audit streams keyed by it, which outlive the vertex. Vertex
+hard-deletion is housekeeping, not a Right-to-Erasure event.

--- a/NTO/Integration/Decisions/Audit/entities/ActionInvocation.ttl
+++ b/NTO/Integration/Decisions/Audit/entities/ActionInvocation.ttl
@@ -1,0 +1,49 @@
+@prefix ogit:                              <http://www.purl.org/ogit/> .
+@prefix ogit.Integration.Decisions.Audit:        <http://www.purl.org/ogit/Integration/Decisions/Audit/> .
+@prefix ogit.Integration:                  <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                              <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                           <http://purl.org/dc/terms/> .
+
+ogit.Integration.Decisions.Audit:ActionInvocation
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "ActionInvocation";
+	dcterms:description """Short-lived vertex representing one Action-
+	Outbound invocation. Per PLAN D34 immutable after create; carries
+	actionId, operationType, target, createdAt, expected_closure (when
+	declared), plus edges to Authority and ConnectorRun. Exists while the
+	action is pending (closure open); after the lifecycle reaches a terminal
+	state, the vertex is retained for vertexTtlDays (default 90 per
+	ActionPolicy) and then hard-deleted.
+
+	Audit-namespace placement note: ActionInvocation lives in Decisions/Audit/
+	because the **audit-forever invariant applies to the TSDB streams**
+	(lifecycle + 16-field audit per PLAN D28 / D30a), not to the vertex
+	itself. The vertex is ephemeral by design (vertex-TTL after closure);
+	the audit content survives in the streams. Right-to-Erasure must NOT
+	touch the streams; the vertex hard-delete is operational housekeeping,
+	not an RtE event.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:actionId
+		ogit.Integration:operationType
+		ogit:createdAt
+	);
+	ogit:optional-attributes (
+		ogit.Integration:targetResourceRef
+		ogit.Integration:expectedClosurePayload
+		ogit.Integration:invocationAttempt
+		ogit.Integration:vertexTtlDeadline
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:actionId
+		ogit.Integration:operationType
+	);
+	ogit:allowed (
+		[ ogit.Integration:invokedBy    ogit.Integration:ConnectorRun ]
+		[ ogit.Integration:authorisedBy ogit.Integration:Authority ]
+	);
+.

--- a/NTO/Integration/Decisions/Audit/entities/SchemaDriftCandidate.ttl
+++ b/NTO/Integration/Decisions/Audit/entities/SchemaDriftCandidate.ttl
@@ -1,0 +1,65 @@
+@prefix ogit:                              <http://www.purl.org/ogit/> .
+@prefix ogit.Integration.Decisions.Audit:        <http://www.purl.org/ogit/Integration/Decisions/Audit/> .
+@prefix ogit.Integration:                  <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                              <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                           <http://purl.org/dc/terms/> .
+
+ogit.Integration.Decisions.Audit:SchemaDriftCandidate
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "SchemaDriftCandidate";
+	dcterms:description """Pending review for a source record that no
+	MappingRule version recognises. Created when a connector reads a
+	source field shape not covered by any version-conditional MappingRule
+	(per Identity v2 Section 25 / SourceVersion entity). Operator inspects
+	the unrecognised payload and decides: add a MappingRule for the new
+	source version, ignore the field, or escalate to source-team. Per
+	Viktor fourth-batch Comment 9 migration-resilience.
+
+	PII discipline (this entity lives in Decisions/Audit/ which survives
+	Right-to-Erasure): sourceId and unrecognisedPayload MUST
+	be pseudonymised at ingest -- the audit-forever guarantee covers
+	the structural record, not raw PII content. Both attributes carry
+	the [PII-CONDITIONAL] / [PII-PSEUDONYMISED-REQUIRED] description
+	prefix; the framework's pre-persistence transform (concept doc
+	Section 6.2) enforces the scrubbing rule before any
+	SchemaDriftCandidate vertex is created. Schema-level enforcement
+	is not possible in OGIT today; the constraint is a framework-
+	boundary contract.
+
+	**Residual-risk acknowledgment (concept doc Section 6.2):** the
+	mandatory cardinality of both attributes plus the audit-forever
+	namespace placement means that if the pre-persistence transform
+	is bypassed (direct graph API call, migration script, framework
+	bug) raw PII can land in `Decisions/Audit/` permanently with no
+	RtE recovery path. The schema has no fallback. Mitigations:
+	(a) every create path MUST go through the framework's
+	`SchemaDriftCandidateService`; (b) the framework rejects creates
+	where the values fail a sentinel-prefix check on the pseudonym
+	format; (c) periodic forensic scans on `Decisions/Audit/` detect
+	policy violations. The schema-level alternative -- making both
+	attributes optional -- was rejected because a null source-record
+	identifier destroys the audit value.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:driftStatus
+		ogit.Integration:detectedAt
+		ogit.Integration:unrecognisedPayload
+		ogit:sourceId
+	);
+	ogit:optional-attributes (
+		ogit.Integration:assignedReviewerId
+		ogit.Integration:resolvedAt
+		ogit.Integration:resolutionDecision
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:driftStatus
+	);
+	ogit:allowed (
+		[ ogit.Integration:detectedFor   ogit.Integration:ConnectorInstance ]
+		[ ogit.Integration:relatedToVersion ogit.Integration:SourceVersion ]
+	);
+.

--- a/NTO/Integration/Decisions/Audit/entities/ValueDriftCandidate.ttl
+++ b/NTO/Integration/Decisions/Audit/entities/ValueDriftCandidate.ttl
@@ -1,0 +1,41 @@
+@prefix ogit:                              <http://www.purl.org/ogit/> .
+@prefix ogit.Integration.Decisions.Audit:        <http://www.purl.org/ogit/Integration/Decisions/Audit/> .
+@prefix ogit.Integration:                  <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                              <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                           <http://purl.org/dc/terms/> .
+
+ogit.Integration.Decisions.Audit:ValueDriftCandidate
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "ValueDriftCandidate";
+	dcterms:description """Pending value-domain-drift detection for a
+	MappingRule that references a CanonicalValueSet. Created when the
+	chi-squared distribution of incoming values shifts beyond the drift
+	threshold over the configured window. Carries the affected MappingRule
+	reference, the observed value distribution, the canonical set
+	reference, and the test statistic. Operator reviews and decides:
+	extend the canonical set, restrict the MappingRule, or accept the
+	drift. Per Identity v2 Section 27.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:driftStatus
+		ogit.Integration:detectedAt
+		ogit.Integration:observedDistributionPayload
+		ogit.Integration:testStatistic
+	);
+	ogit:optional-attributes (
+		ogit.Integration:assignedReviewerId
+		ogit.Integration:resolvedAt
+		ogit.Integration:resolutionDecision
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:driftStatus
+	);
+	ogit:allowed (
+		[ ogit.Integration:detectedFor    ogit.Integration:MappingRule ]
+		[ ogit.Integration:comparedAgainst ogit.Integration:CanonicalValueSet ]
+	);
+.

--- a/NTO/Integration/Decisions/PII/README.md
+++ b/NTO/Integration/Decisions/PII/README.md
@@ -1,0 +1,13 @@
+# Integration / Decisions / PII
+
+## Overview
+
+The PII-bearing decision-and-lifecycle vertices the Connector Framework
+produces. Right-to-Erasure (GDPR Art. 17) has a bounded target by traversing
+this sub-namespace.
+
+Entities: IdentityCandidate, IdentityCandidateOption, MergeJob, SplitJob,
+Conflict, UserAction, SubjectRequest.
+
+The platform's Right-to-Erasure executor scopes every erasure to this namespace
+plus the source-side attribute writes recorded in the timeseries store.

--- a/NTO/Integration/Decisions/PII/entities/Conflict.ttl
+++ b/NTO/Integration/Decisions/PII/entities/Conflict.ttl
@@ -1,0 +1,46 @@
+@prefix ogit:                              <http://www.purl.org/ogit/> .
+@prefix ogit.Integration.Decisions.PII:        <http://www.purl.org/ogit/Integration/Decisions/PII/> .
+@prefix ogit.Integration:                  <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                              <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                           <http://purl.org/dc/terms/> .
+
+ogit.Integration.Decisions.PII:Conflict
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "Conflict";
+	dcterms:description """Pending conflict awaiting manual review. Created
+	when a ConflictResolutionRule resolves to 'manual' for an incoming write
+	whose target attribute already has a competing value from a different
+	source. Carries a soft reference to the affected entity vertex (via the
+	affectedVertexXid attribute, since OGIT has no any-vertex edge target),
+	plus edges to the proposing and incumbent ConnectorRun, and the proposed
+	and incumbent values as payload attributes. Per PLAN D14 (no-silent-
+	defaults). UI is a separate Bardioc Desktop app, downstream concern.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:conflictStatus
+		ogit.Integration:affectedVertexXid
+		ogit.Integration:targetAttribute
+		ogit.Integration:proposedValuePayload
+		ogit.Integration:incumbentValuePayload
+		ogit:createdAt
+	);
+	ogit:optional-attributes (
+		ogit.Integration:assignedReviewerId
+		ogit.Integration:resolvedAt
+		ogit.Integration:resolutionDecision
+		ogit.Integration:becomesRule
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:conflictStatus
+		ogit.Integration:affectedVertexXid
+		ogit.Integration:targetAttribute
+	);
+	ogit:allowed (
+		[ ogit.Integration:proposedBy      ogit.Integration:ConnectorRun ]
+		[ ogit.Integration:incumbentFrom   ogit.Integration:ConnectorRun ]
+	);
+.

--- a/NTO/Integration/Decisions/PII/entities/IdentityCandidate.ttl
+++ b/NTO/Integration/Decisions/PII/entities/IdentityCandidate.ttl
@@ -1,0 +1,43 @@
+@prefix ogit:                              <http://www.purl.org/ogit/> .
+@prefix ogit.Integration.Decisions.PII:        <http://www.purl.org/ogit/Integration/Decisions/PII/> .
+@prefix ogit.Integration:                  <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                              <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                           <http://purl.org/dc/terms/> .
+
+ogit.Integration.Decisions.PII:IdentityCandidate
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "IdentityCandidate";
+	dcterms:description """Pending identity resolution awaiting manual review.
+	Surfaces in the operator's review queue when a heuristic IdentityResolver
+	returns a borderline confidence (between low-reject and high-accept
+	thresholds) for a source record. Carries the source-record reference,
+	the ConnectorRun context, the list of candidate options (each an
+	IdentityCandidateOption sub-entity), and the evidence JSON the resolver
+	used. Lives under NTO/Integration/Decisions/ for PII-isolation per
+	Identity v2 Section 34 (right-to-erasure bounded target). The reused ogit:sourceId here is the raw source-record identifier -- acceptable on this PII-namespace entity (the former source_record_id [PII-CONDITIONAL] context: raw is acceptable and is purged on Right-to-Erasure together with the vertex); the generic base attribute cannot carry the marker, so the discipline is recorded on this entity.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:candidateStatus
+		ogit:sourceId
+		ogit.Integration:resolverId
+		ogit:createdAt
+	);
+	ogit:optional-attributes (
+		ogit.Integration:assignedReviewerId
+		ogit.Integration:resolvedAt
+		ogit.Integration:resolutionDecision
+		ogit.Integration:operatorNote
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:candidateStatus
+		ogit.Integration:resolverId
+	);
+	ogit:allowed (
+		[ ogit.Integration:proposedBy   ogit.Integration:ConnectorRun ]
+		[ ogit.Integration:hasOption    ogit.Integration.Decisions.PII:IdentityCandidateOption ]
+	);
+.

--- a/NTO/Integration/Decisions/PII/entities/IdentityCandidateOption.ttl
+++ b/NTO/Integration/Decisions/PII/entities/IdentityCandidateOption.ttl
@@ -1,0 +1,35 @@
+@prefix ogit:                              <http://www.purl.org/ogit/> .
+@prefix ogit.Integration.Decisions.PII:        <http://www.purl.org/ogit/Integration/Decisions/PII/> .
+@prefix ogit.Integration:                  <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                              <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                           <http://purl.org/dc/terms/> .
+
+ogit.Integration.Decisions.PII:IdentityCandidateOption
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "IdentityCandidateOption";
+	dcterms:description """Sub-entity of IdentityCandidate. One candidate
+	vertex that the resolver returned as a possible identity match for the
+	source record, with its confidence score and the resolver's evidence
+	payload. An IdentityCandidate typically carries multiple options for
+	the reviewer to choose from.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:candidateVertexXid
+		ogit:confidence
+		ogit.Integration:evidencePayload
+	);
+	ogit:optional-attributes (
+		ogit:rank
+		ogit.Integration:resolverSubcomponentId
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:candidateVertexXid
+	);
+	ogit:allowed (
+		[ ogit:isPartOf ogit.Integration.Decisions.PII:IdentityCandidate ]
+	);
+.

--- a/NTO/Integration/Decisions/PII/entities/MergeJob.ttl
+++ b/NTO/Integration/Decisions/PII/entities/MergeJob.ttl
@@ -1,0 +1,44 @@
+@prefix ogit:                              <http://www.purl.org/ogit/> .
+@prefix ogit.Integration.Decisions.PII:        <http://www.purl.org/ogit/Integration/Decisions/PII/> .
+@prefix ogit.Integration:                  <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                              <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                           <http://purl.org/dc/terms/> .
+
+ogit.Integration.Decisions.PII:MergeJob
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "MergeJob";
+	dcterms:description """State machine for one merge operation under the
+	MergeOrchestrator (Identity v2 Section 6.3 / 6.4). Carries the
+	checkpoint state, the source vertex identity, the merge target, and the
+	atomicity-discipline guards (Rule 1 abort-on-partial-completion before
+	source-delete; Rule 2 audit persisted before source-delete commits).
+	Crash-recovery replays from the latest checkpoint without producing
+	duplicate effects. The May 2026 OSINT smoke run (LI/MT/CY/BS, 948 edges
+	lost) is the empirical anchor for the atomicity rules.""";
+	dcterms:valid "start=2026-05-21;revised=2026-06-05;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:jobState
+		ogit.Integration:sourceVertexXid
+		ogit.Integration:targetVertexXid
+		ogit.Integration:checkpointPayload
+		ogit:createdAt
+	);
+	ogit:optional-attributes (
+		ogit:finishedAt
+		ogit:reason
+		ogit.Integration:recoveryCount
+		ogit.Integration:operatorNote
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:jobState
+		ogit.Integration:sourceVertexXid
+	);
+	ogit:allowed (
+		[ ogit.Integration:initiatedByRun  ogit.Integration:ConnectorRun ]
+		[ ogit.Integration:authorisedBy ogit.Integration:Authority ]
+	);
+.

--- a/NTO/Integration/Decisions/PII/entities/SplitJob.ttl
+++ b/NTO/Integration/Decisions/PII/entities/SplitJob.ttl
@@ -1,0 +1,46 @@
+@prefix ogit:                              <http://www.purl.org/ogit/> .
+@prefix ogit.Integration.Decisions.PII:        <http://www.purl.org/ogit/Integration/Decisions/PII/> .
+@prefix ogit.Integration:                  <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                              <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                           <http://purl.org/dc/terms/> .
+
+ogit.Integration.Decisions.PII:SplitJob
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "SplitJob";
+	dcterms:description """State machine for one split operation that corrects
+	a prior over-binding: two source records were auto-bound to a single
+	vertex but later evidence shows them to be different real-world entities
+	(Identity v2 Section 7.2). The job rebinds the contributions to two
+	target vertices. State transitions: PROPOSED -> VALIDATED -> SPLITTING
+	-> COMPLETED | FAILED. Crash-recovery replays from the latest
+	checkpoint. The Rule-1 and Rule-2 atomicity discipline of the
+	MergeOrchestrator (Section 6.4) applies: no commit until the inverse
+	merge audit is durable. Eight conformance tests parallel to MergeJob
+	(Section 8) gate Phase B exit.""";
+	dcterms:valid "start=2026-05-29;revised=2026-06-05;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:jobState
+		ogit.Integration:sourceVertexXid
+		ogit.Integration:proposedTargetXids
+		ogit.Integration:checkpointPayload
+		ogit:createdAt
+	);
+	ogit:optional-attributes (
+		ogit:finishedAt
+		ogit:reason
+		ogit.Integration:recoveryCount
+		ogit.Integration:operatorNote
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:jobState
+		ogit.Integration:sourceVertexXid
+	);
+	ogit:allowed (
+		[ ogit.Integration:initiatedByRun  ogit.Integration:ConnectorRun ]
+		[ ogit.Integration:authorisedBy ogit.Integration:Authority ]
+	);
+.

--- a/NTO/Integration/Decisions/PII/entities/SubjectRequest.ttl
+++ b/NTO/Integration/Decisions/PII/entities/SubjectRequest.ttl
@@ -1,0 +1,45 @@
+@prefix ogit:                              <http://www.purl.org/ogit/> .
+@prefix ogit.Integration.Decisions.PII:        <http://www.purl.org/ogit/Integration/Decisions/PII/> .
+@prefix ogit.Integration:                  <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                              <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                           <http://purl.org/dc/terms/> .
+
+ogit.Integration.Decisions.PII:SubjectRequest
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "SubjectRequest";
+	dcterms:description """Data Subject Rights request workflow record per
+	Identity v2 Section 21. State machine over the DPO segregation-of-duties
+	flow: intake (clerk) -> approver (DPO approver) -> executor (DPO
+	executor). Two workflows differentiated by requestType: Subject Access
+	Request (report generation, no deletion) and Right-to-Erasure
+	(documented purge). Carries the subject identifier, the legal-retention
+	override (with cited legal basis if applicable), and the executor
+	audit. Hard rule: structural identity-history audit fields persist
+	after RtE; only PII content is purged.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:requestType
+		ogit.Integration:requestState
+		ogit.Integration:subjectIdentifier
+		ogit:createdAt
+		ogit.Integration:intakeActorId
+	);
+	ogit:optional-attributes (
+		ogit.Integration:approverActorId
+		ogit.Integration:executorActorId
+		ogit.Integration:approvedAt
+		ogit.Integration:executedAt
+		ogit.Integration:legalRetentionOverride
+		ogit.Integration:legalBasisCitation
+		ogit.Integration:requestPayload
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:requestState
+		ogit.Integration:requestType
+	);
+	ogit:allowed ( );
+.

--- a/NTO/Integration/Decisions/PII/entities/UserAction.ttl
+++ b/NTO/Integration/Decisions/PII/entities/UserAction.ttl
@@ -1,0 +1,39 @@
+@prefix ogit:                              <http://www.purl.org/ogit/> .
+@prefix ogit.Integration.Decisions.PII:        <http://www.purl.org/ogit/Integration/Decisions/PII/> .
+@prefix ogit.Integration:                  <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                              <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                           <http://purl.org/dc/terms/> .
+
+ogit.Integration.Decisions.PII:UserAction
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "UserAction";
+	dcterms:description """Persisted transient source-triggered event:
+	button clicks in adaptive cards, slash-commands, webhook-receives,
+	approval signals. Per PLAN D29 these are NOT a separate Action-Inbound
+	mode; they are Data-Inbound records that the engine subscribes to like
+	any other graph datum. Lives under Decisions/ for PII-isolation (user
+	identifiers, free-text payloads).""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:userActionType
+		ogit.Integration:sourceSystemId
+		ogit.Integration:triggeredAt
+		ogit.Integration:receivedAt
+	);
+	ogit:optional-attributes (
+		ogit.Integration:userIdentifier
+		ogit.Integration:userActionPayload
+		ogit.Integration:relatedEntityRef
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:userActionType
+		ogit.Integration:sourceSystemId
+	);
+	ogit:allowed (
+		[ ogit.Integration:receivedVia ogit.Integration:ConnectorInstance ]
+	);
+.

--- a/NTO/Integration/Decisions/README.md
+++ b/NTO/Integration/Decisions/README.md
@@ -1,0 +1,24 @@
+# Integration / Decisions
+
+## Overview
+
+Decision-and-lifecycle vertices the Connector Framework produces during
+operation, split into two sub-children with disjoint Right-to-Erasure semantics:
+
+- `Decisions/PII/` (seven entities) -- the Right-to-Erasure target (GDPR
+  Art. 17). Entities carry PII directly or are per-Subject decision records:
+  manual-review entries (IdentityCandidate, IdentityCandidateOption), merge and
+  split workflows (MergeJob, SplitJob), conflict awaiters (Conflict), transient
+  source events (UserAction), Data-Subject-Rights workflows (SubjectRequest).
+- `Decisions/Audit/` (three entities) -- audit records that MUST survive
+  Right-to-Erasure: ValueDriftCandidate, SchemaDriftCandidate, ActionInvocation.
+
+**Right-to-Erasure rule.** RtE sweeps target `Decisions/PII/` only; an executor
+traversing `Decisions/` indiscriminately would erase audit records.
+Implementations MUST check the sub-namespace before delete.
+
+**Audit-forever applies to streams, not vertices.** ActionInvocation is an
+ephemeral vertex (hard-deleted after its terminal state to bound warm-tier
+size); the audit guarantee is on the timeseries / audit streams keyed by it,
+which outlive the vertex. Vertex hard-deletion is housekeeping, not a
+Right-to-Erasure event.

--- a/NTO/Integration/README.md
+++ b/NTO/Integration/README.md
@@ -1,0 +1,23 @@
+# Integration
+
+## Overview
+
+The schema additions the Bardioc Connector Framework needs to operate as a
+platform layer: connector blueprints and their deployment-time instances, the
+immutable run history, the mapping / netting / conflict / weaving / action rule
+entities, the authority chain, and the multi-team governance signatures.
+
+Although developed for the Bardioc Connector Framework 2.0, these entities are
+modelled to stand on their own: a general semantic vocabulary for data
+integration -- the path from a source, through mapping, netting and conflict
+resolution, to a governed, provenance-tracked write. The intent is a shared OGIT
+understanding of data-integration paths, not only the backing schema for one
+framework's implementation.
+
+The PII-bearing decision-and-lifecycle vertices (manual-review entries, merge
+and split jobs, conflicts, transient user actions, DSR requests, drift
+candidates, action invocations) live in `Decisions/`. This namespace itself is
+structural and PII-free; Right-to-Erasure targets `Decisions/PII/` alone.
+
+Conventions common to every OGIT namespace (creator, fixed value sets, edge
+targets, additive-only) are in the repository root README.

--- a/NTO/Integration/attributes/ackSemantic.ttl
+++ b/NTO/Integration/attributes/ackSemantic.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ackSemantic
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "ackSemantic";
+	dcterms:description "Acknowledgement semantic per D26.2 (best_effort / durable).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "best_effort,durable";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/acquiredAt.ttl
+++ b/NTO/Integration/attributes/acquiredAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:acquiredAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "acquiredAt";
+	dcterms:description "Timestamp at which the lock was acquired.";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/actionId.ttl
+++ b/NTO/Integration/attributes/actionId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:actionId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "actionId";
+	dcterms:description "ULID identifying an action through its full lifecycle (D32).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/actionPolicyOverrideRef.ttl
+++ b/NTO/Integration/attributes/actionPolicyOverrideRef.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:actionPolicyOverrideRef
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "actionPolicyOverrideRef";
+	dcterms:description "Optional per-instance override of the connector-default ActionPolicy. When set, this attribute takes precedence over any `appliesTo` edge from the connector-default ActionPolicy to this ConnectorInstance. Same override semantics as `nettingPolicyOverrideRef` (which see).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/actionPolicyPayload.ttl
+++ b/NTO/Integration/attributes/actionPolicyPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:actionPolicyPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "actionPolicyPayload";
+	dcterms:description "Immutable JSON payload of the action policy captured for a Run.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/adjudicatedAt.ttl
+++ b/NTO/Integration/attributes/adjudicatedAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:adjudicatedAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "adjudicatedAt";
+	dcterms:description "Adjudication timestamp.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/adjudicationDecision.ttl
+++ b/NTO/Integration/attributes/adjudicationDecision.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:adjudicationDecision
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "adjudicationDecision";
+	dcterms:description "Adjudicator's final decision. approve / reject / abstain are parallel to reviewDecision and cover first-instance adjudication without a prior reviewer pass; uphold_reviewer and overrule_reviewer cover the reviewer-escalation path and make the adjudication-versus-reviewer relationship explicit. The five-value enum was resolved by F32 quorum disposition on 2026-06-02 (closed; no further changes expected).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "approve,reject,abstain,uphold_reviewer,overrule_reviewer";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/adjudicationNotes.ttl
+++ b/NTO/Integration/attributes/adjudicationNotes.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:adjudicationNotes
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "adjudicationNotes";
+	dcterms:description "[PII-FORBIDDEN] Free-form adjudicator notes attached to a rule revision. Same discipline as `reviewNotes`: the host entity (Adjudicator) is structural and survives Right-to-Erasure, so this field MUST NOT contain subject PII. The framework's pre-persistence transform scans for known PII patterns and rejects writes that match. The [PII-FORBIDDEN] description prefix is a machine-greppable Almato convention.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/adjudicatorId.ttl
+++ b/NTO/Integration/attributes/adjudicatorId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:adjudicatorId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "adjudicatorId";
+	dcterms:description "Adjudicator identity.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/adjudicatorSignature.ttl
+++ b/NTO/Integration/attributes/adjudicatorSignature.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:adjudicatorSignature
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "adjudicatorSignature";
+	dcterms:description "Cryptographic signature of the adjudicator.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/affectedVertexXid.ttl
+++ b/NTO/Integration/attributes/affectedVertexXid.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:affectedVertexXid
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "affectedVertexXid";
+	dcterms:description "External identifier (xid) of the entity vertex this Conflict is about. Modelled as a soft attribute reference rather than an edge: OGIT has no edge inheritance and no any-vertex edge target, and a Conflict can concern any vertex type a connector writes (PLAN D14; Identity v2 Section 6).";
+	dcterms:valid "start=2026-06-09;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/allowedValuesPayload.ttl
+++ b/NTO/Integration/attributes/allowedValuesPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:allowedValuesPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "allowedValuesPayload";
+	dcterms:description "Declared closed set of allowed values.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/approvedAt.ttl
+++ b/NTO/Integration/attributes/approvedAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:approvedAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "approvedAt";
+	dcterms:description "Approval timestamp for a SubjectRequest.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/approverActorId.ttl
+++ b/NTO/Integration/attributes/approverActorId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:approverActorId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "approverActorId";
+	dcterms:description "DPO approver actor identifier.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/art22InScope.ttl
+++ b/NTO/Integration/attributes/art22InScope.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:art22InScope
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "art22InScope";
+	dcterms:description "Flag the MappingRule as in scope of DSGVO Art. 22 (automated decisions).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "true,false";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/assignedReviewerId.ttl
+++ b/NTO/Integration/attributes/assignedReviewerId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:assignedReviewerId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "assignedReviewerId";
+	dcterms:description "[OPERATOR-IAM-REF] [LEGAL-REVIEW-PENDING] Reviewer identity (operator IAM principal id) assigned to triage the pending decision. The proposed classification treats this as internal operational data (not subject PII): the operator's IAM principal identifies a member of the platform's authorised review staff, not a data subject of the system; employee data protection (where applicable) is delegated to the IAM platform's lifecycle. Under this classification the attribute is NOT swept on subject Right-to-Erasure even on Audit-namespace entities (ValueDriftCandidate, SchemaDriftCandidate). HOWEVER: this classification is provisional pending DPO and legal sign-off (the operator IAM id may qualify as personal data under GDPR Art. 4(1) for EU employees). Until sign-off, framework operators MUST treat any RtE-style request from a reviewer as a separate workflow (not auto-swept). The [LEGAL-REVIEW-PENDING] marker is removed once DPO sign-off lands and the decision is recorded in a PLAN entry.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/authorSeededPriorsPayload.ttl
+++ b/NTO/Integration/attributes/authorSeededPriorsPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:authorSeededPriorsPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "authorSeededPriorsPayload";
+	dcterms:description "Author-seeded per-source trust priors (Beta).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/authorityExternalRef.ttl
+++ b/NTO/Integration/attributes/authorityExternalRef.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:authorityExternalRef
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "authorityExternalRef";
+	dcterms:description "External system reference (URI / contract number).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/authorityLabel.ttl
+++ b/NTO/Integration/attributes/authorityLabel.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:authorityLabel
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "authorityLabel";
+	dcterms:description "Human-readable authority name. MUST be unique per Authority vertex (the framework enforces uniqueness at create-time; duplicate label rejects the create). Together with the OGIT vertex ogit/_id this attribute serves as the stable, queryable handle for an Authority. PLAN D35 requires a non-null authority reference on any framework call; the framework treats `authorityLabel` as that reference for human-readable logging while the immutable ogit/_id is the wire-level handle.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/authorityScopeId.ttl
+++ b/NTO/Integration/attributes/authorityScopeId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:authorityScopeId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "authorityScopeId";
+	dcterms:description "Scope an authority covers (e.g. tenant, jurisdiction).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/authoritySource.ttl
+++ b/NTO/Integration/attributes/authoritySource.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:authoritySource
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "authoritySource";
+	dcterms:description "Named authority-resolution logic that fills authority_id for this operationType (D35).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/authorityType.ttl
+++ b/NTO/Integration/attributes/authorityType.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:authorityType
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "authorityType";
+	dcterms:description "Authority classification: legal_entity / engine_policy / customer_admin / external_party.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "legal_entity,engine_policy,customer_admin,external_party";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/becomesRule.ttl
+++ b/NTO/Integration/attributes/becomesRule.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:becomesRule
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "becomesRule";
+	dcterms:description "Operator flag indicating this conflict resolution should be codified as a future rule.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "true,false";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/betaPosterioriPayload.ttl
+++ b/NTO/Integration/attributes/betaPosterioriPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:betaPosterioriPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "betaPosterioriPayload";
+	dcterms:description "Accumulated Beta posteriori updates per source.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/bidirectional.ttl
+++ b/NTO/Integration/attributes/bidirectional.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:bidirectional
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "bidirectional";
+	dcterms:description "Boolean flag declaring whether this mapping rule is bidirectional. Anchored in PLAN D6 and D22.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "true,false";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/bindBy.ttl
+++ b/NTO/Integration/attributes/bindBy.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:bindBy
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "bindBy";
+	dcterms:description "Deterministic-binding source-record attribute name per PLAN D20.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/bindByResolver.ttl
+++ b/NTO/Integration/attributes/bindByResolver.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:bindByResolver
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "bindByResolver";
+	dcterms:description "Heuristic IdentityResolver identifier per PLAN D20.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/breakerCooldownSeconds.ttl
+++ b/NTO/Integration/attributes/breakerCooldownSeconds.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:breakerCooldownSeconds
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "breakerCooldownSeconds";
+	dcterms:description "Breaker cooldown in seconds. OSINT-validated default 900.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/breakerEnabled.ttl
+++ b/NTO/Integration/attributes/breakerEnabled.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:breakerEnabled
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "breakerEnabled";
+	dcterms:description "Circuit-breaker enable / disable flag (D26.4).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "true,false";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/breakerFailureThreshold.ttl
+++ b/NTO/Integration/attributes/breakerFailureThreshold.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:breakerFailureThreshold
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "breakerFailureThreshold";
+	dcterms:description "Consecutive failure count that trips the breaker. OSINT-validated default 8.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/breakerSelfHeal.ttl
+++ b/NTO/Integration/attributes/breakerSelfHeal.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:breakerSelfHeal
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "breakerSelfHeal";
+	dcterms:description "Whether the breaker self-heals after cooldown (D26.4).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "true,false";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/candidateStatus.ttl
+++ b/NTO/Integration/attributes/candidateStatus.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:candidateStatus
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "candidateStatus";
+	dcterms:description "Lifecycle state of an IdentityCandidate (pending / resolved / withdrawn).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "pending,resolved,withdrawn";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/candidateVertexXid.ttl
+++ b/NTO/Integration/attributes/candidateVertexXid.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:candidateVertexXid
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "candidateVertexXid";
+	dcterms:description "Candidate vertex offered by the resolver as a possible identity match.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/celPredicate.ttl
+++ b/NTO/Integration/attributes/celPredicate.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:celPredicate
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "celPredicate";
+	dcterms:description "Optional CEL predicate for fine-grained match (D16).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/celTransform.ttl
+++ b/NTO/Integration/attributes/celTransform.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:celTransform
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "celTransform";
+	dcterms:description "Optional CEL expression for inline transformation (D16).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/checkpointPayload.ttl
+++ b/NTO/Integration/attributes/checkpointPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:checkpointPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "checkpointPayload";
+	dcterms:description "[PII-BEARING] [NULLED-ON-TERMINAL-STATE] MergeOrchestrator / SplitOrchestrator crash-recovery checkpoint state. May snapshot vertex attribute values including any PII the merge or split is transferring between vertices. Allowed only on entities under `Decisions/PII/` (the RtE target); the framework rejects writes that attach `checkpointPayload` to an entity outside `Decisions/PII/`. **PII-footprint contract:** the framework MUST null out this attribute when the host job (MergeJob / SplitJob) transitions to a terminal state (COMPLETED / FAILED); the checkpoint is only required during crash recovery and serves no audit purpose after terminal-state convergence. Concept doc Section 6.2 records this as a framework-boundary contract.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/closureEnabled.ttl
+++ b/NTO/Integration/attributes/closureEnabled.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:closureEnabled
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "closureEnabled";
+	dcterms:description "Whether ActionPolicy enables the Closure-Loop for this operationType.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "true,false";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/closureMatchDataPath.ttl
+++ b/NTO/Integration/attributes/closureMatchDataPath.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:closureMatchDataPath
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "closureMatchDataPath";
+	dcterms:description "Typed OGIT path the closure queue matches inbound records against (D30).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/closureMatchEquals.ttl
+++ b/NTO/Integration/attributes/closureMatchEquals.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:closureMatchEquals
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "closureMatchEquals";
+	dcterms:description "Expected value or reference ($actionId / $parameters.x) for closure match (D30).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/closureOnTimeout.ttl
+++ b/NTO/Integration/attributes/closureOnTimeout.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:closureOnTimeout
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "closureOnTimeout";
+	dcterms:description "On-timeout policy: failed_signal / retry_n / drop (D30).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "failed_signal,retry_n,drop";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/closureRetryLimit.ttl
+++ b/NTO/Integration/attributes/closureRetryLimit.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:closureRetryLimit
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "closureRetryLimit";
+	dcterms:description "Maximum closure-timeout retry count (D30).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/closureTimeoutSeconds.ttl
+++ b/NTO/Integration/attributes/closureTimeoutSeconds.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:closureTimeoutSeconds
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "closureTimeoutSeconds";
+	dcterms:description "Closure timeout in seconds (Action-Closure-Loop D30).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/coalesceWindowEvents.ttl
+++ b/NTO/Integration/attributes/coalesceWindowEvents.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:coalesceWindowEvents
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "coalesceWindowEvents";
+	dcterms:description "Coalescing window size threshold (D26.1).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/coalesceWindowSeconds.ttl
+++ b/NTO/Integration/attributes/coalesceWindowSeconds.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:coalesceWindowSeconds
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "coalesceWindowSeconds";
+	dcterms:description "Coalescing window time threshold (D26.1).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/conflictRulesPayload.ttl
+++ b/NTO/Integration/attributes/conflictRulesPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:conflictRulesPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "conflictRulesPayload";
+	dcterms:description "Immutable JSON payload of the conflict-resolution rules captured for a Run.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/conflictStatus.ttl
+++ b/NTO/Integration/attributes/conflictStatus.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:conflictStatus
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "conflictStatus";
+	dcterms:description "Lifecycle state of a Conflict entity. open = newly raised, not yet adjudicated; resolved = decided via ConflictResolutionRule or manual adjudication; withdrawn = retracted by proposing side before adjudication; converted_to_rule = adjudication outcome codified as a new ConflictResolutionRule via becomesRule=true. The four-value enum was resolved by F31 quorum disposition on 2026-06-02 (closed; no further changes expected).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "open,resolved,withdrawn,converted_to_rule";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/constraintExpression.ttl
+++ b/NTO/Integration/attributes/constraintExpression.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:constraintExpression
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "constraintExpression";
+	dcterms:description "CEL predicate over related attributes for the constraint_derived strategy. The chosen value must satisfy the predicate; candidates that fail the predicate are rejected.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/credentialsRef.ttl
+++ b/NTO/Integration/attributes/credentialsRef.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:credentialsRef
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "credentialsRef";
+	dcterms:description "[SECRET-REF] Vault-resolvable reference URI to instance credentials. MUST be a backend-agnostic reference of the form <backend>://<path>#<field>, never a plaintext secret and never a directly-resolvable HTTP(S) URL. The framework resolves the reference at deploy time and injects the resolved value into the connector pod environment. The regex restricts the scheme to a fixed allowlist (`vault`, `aws-sm`, `gcp-sm`, `azure-kv`, `k8s-secret`); HTTP(S) and other freely-resolvable URI schemes are rejected.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:validation-type "regex";
+	ogit:validation-parameter "^(vault|aws-sm|gcp-sm|azure-kv|k8s-secret)://[^#\\s]+#[^\\s]+$";
+.

--- a/NTO/Integration/attributes/customerId.ttl
+++ b/NTO/Integration/attributes/customerId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:customerId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "customerId";
+	dcterms:description "Customer tenant identifier this instance serves.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/dataClassificationPayload.ttl
+++ b/NTO/Integration/attributes/dataClassificationPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:dataClassificationPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "dataClassificationPayload";
+	dcterms:description "Immutable JSON payload of the data-classification assignments captured for a Run.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/dataMaturityTier.ttl
+++ b/NTO/Integration/attributes/dataMaturityTier.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:dataMaturityTier
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "dataMaturityTier";
+	dcterms:description "Dev / test / prod tier classification per Identity v2 Section 23.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "dev,test,prod";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/declaredAt.ttl
+++ b/NTO/Integration/attributes/declaredAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:declaredAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "declaredAt";
+	dcterms:description "Timestamp at which the source version was declared.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/dedupWindowSeconds.ttl
+++ b/NTO/Integration/attributes/dedupWindowSeconds.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:dedupWindowSeconds
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "dedupWindowSeconds";
+	dcterms:description "Action dedup window. Default 86400 (24 hours) per D32.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/deprecationPhase.ttl
+++ b/NTO/Integration/attributes/deprecationPhase.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:deprecationPhase
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "deprecationPhase";
+	dcterms:description "Deprecation lifecycle phase (announcement / soft / hard / removed) per Identity v2 Section 14.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "announcement,soft,hard,removed";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/detectedAt.ttl
+++ b/NTO/Integration/attributes/detectedAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:detectedAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "detectedAt";
+	dcterms:description "Detection timestamp for a drift candidate.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/direction.ttl
+++ b/NTO/Integration/attributes/direction.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:direction
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "direction";
+	dcterms:description "Inbound or outbound direction this NettingPolicy applies to.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "inbound,outbound";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/driftChiSquaredThreshold.ttl
+++ b/NTO/Integration/attributes/driftChiSquaredThreshold.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:driftChiSquaredThreshold
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "driftChiSquaredThreshold";
+	dcterms:description "Chi-squared threshold above which drift is flagged.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/driftStatus.ttl
+++ b/NTO/Integration/attributes/driftStatus.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:driftStatus
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "driftStatus";
+	dcterms:description "Lifecycle state of a drift candidate (pending / triaged / accepted / rejected).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "pending,triaged,accepted,rejected";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/driftWindowDays.ttl
+++ b/NTO/Integration/attributes/driftWindowDays.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:driftWindowDays
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "driftWindowDays";
+	dcterms:description "Window over which the drift statistic is computed.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/droppedPayloadRetentionDays.ttl
+++ b/NTO/Integration/attributes/droppedPayloadRetentionDays.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:droppedPayloadRetentionDays
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "droppedPayloadRetentionDays";
+	dcterms:description "Cold-tier retention duration for DROP_OLDEST dropped payloads (Sub-Q6: 365 days).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/durableSubstrate.ttl
+++ b/NTO/Integration/attributes/durableSubstrate.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:durableSubstrate
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "durableSubstrate";
+	dcterms:description "Durable substrate selector for outbound ack per D26.9. Today kafka is the only supported value; the attribute is intentionally extensible (no fixed validation) because additional substrates (e.g. Pulsar, NATS-JetStream) may be added without a schema change.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/edgeType.ttl
+++ b/NTO/Integration/attributes/edgeType.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:edgeType
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "edgeType";
+	dcterms:description "OGIT edge type the weaver creates between matched pairs.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/emittedAt.ttl
+++ b/NTO/Integration/attributes/emittedAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:emittedAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "emittedAt";
+	dcterms:description "Timestamp at which the signal was emitted.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/endpoint.ttl
+++ b/NTO/Integration/attributes/endpoint.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:endpoint
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "endpoint";
+	dcterms:description "Source-system endpoint URI for this instance.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/evidencePayload.ttl
+++ b/NTO/Integration/attributes/evidencePayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:evidencePayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "evidencePayload";
+	dcterms:description "[PII-BEARING] Resolver-supplied evidence JSON supporting an IdentityCandidateOption. Typically includes source-record excerpts with names, identifiers, contact data. Allowed only on entities under `Decisions/PII/` (the RtE target); the framework rejects writes that attach `evidencePayload` to an entity outside `Decisions/PII/`.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/ewmaSecondaryPayload.ttl
+++ b/NTO/Integration/attributes/ewmaSecondaryPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ewmaSecondaryPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "ewmaSecondaryPayload";
+	dcterms:description "Secondary EWMA tracking payload for retrospective dual-algorithm comparison.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/executedAt.ttl
+++ b/NTO/Integration/attributes/executedAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:executedAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "executedAt";
+	dcterms:description "Execution timestamp for a SubjectRequest.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/executorActorId.ttl
+++ b/NTO/Integration/attributes/executorActorId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:executorActorId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "executorActorId";
+	dcterms:description "DPO executor actor identifier.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/expectedClosurePayload.ttl
+++ b/NTO/Integration/attributes/expectedClosurePayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:expectedClosurePayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "expectedClosurePayload";
+	dcterms:description "Closure declaration captured on this ActionInvocation (data_path, equals, timeout, on_timeout).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/expectedNeighbourhood.ttl
+++ b/NTO/Integration/attributes/expectedNeighbourhood.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:expectedNeighbourhood
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "expectedNeighbourhood";
+	dcterms:description "OGIT expectedNeighbourhood declaration for topological completeness (Identity v2 Sec 26).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/expectedReleaseAt.ttl
+++ b/NTO/Integration/attributes/expectedReleaseAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:expectedReleaseAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "expectedReleaseAt";
+	dcterms:description "Operator-supplied estimate of when the lock will be released; advisory, not enforced.";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/expertRuleExpression.ttl
+++ b/NTO/Integration/attributes/expertRuleExpression.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:expertRuleExpression
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "expertRuleExpression";
+	dcterms:description "CEL expression evaluating the candidate contributions for the expert_system_driven strategy. The expression returns the chosen value; the framework evaluates it against the candidate set at write time.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/fieldsPayload.ttl
+++ b/NTO/Integration/attributes/fieldsPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:fieldsPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "fieldsPayload";
+	dcterms:description "Expected source-side field shapes for this version.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/frameworkMax.ttl
+++ b/NTO/Integration/attributes/frameworkMax.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:frameworkMax
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "frameworkMax";
+	dcterms:description "Maximum kernel version the blueprint is compatible with.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/frameworkMin.ttl
+++ b/NTO/Integration/attributes/frameworkMin.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:frameworkMin
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "frameworkMin";
+	dcterms:description "Minimum kernel version the blueprint is compatible with.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/holderId.ttl
+++ b/NTO/Integration/attributes/holderId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:holderId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "holderId";
+	dcterms:description "Identifier of the entity that holds the lock (operator id, MergeJob id, or kernel-process id).";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/holderKind.ttl
+++ b/NTO/Integration/attributes/holderKind.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:holderKind
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "holderKind";
+	dcterms:description "Classification of the lock holder (OGIT Extensions A.16a).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "operator,merge_job,kernel";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/identityResolverConfigPayload.ttl
+++ b/NTO/Integration/attributes/identityResolverConfigPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:identityResolverConfigPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "identityResolverConfigPayload";
+	dcterms:description "Immutable JSON payload of the identity-resolver configuration captured for a Run.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/incumbentValuePayload.ttl
+++ b/NTO/Integration/attributes/incumbentValuePayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:incumbentValuePayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "incumbentValuePayload";
+	dcterms:description "[PII-BEARING] Currently-held value payload that the proposed value contests. Same PII discipline as `proposedValuePayload`: if the contested attribute is PII, this payload carries it. Allowed only on entities under `Decisions/PII/` (the RtE target); the framework rejects writes that attach `incumbentValuePayload` to an entity outside `Decisions/PII/`.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/instanceStatus.ttl
+++ b/NTO/Integration/attributes/instanceStatus.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:instanceStatus
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "instanceStatus";
+	dcterms:description "Lifecycle state (registered / deployed / running / paused / retiring / retired) of the instance. See `12_netting_state_machine_spec.md` Section 5A for the formal state-machine.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "registered,deployed,running,paused,retiring,retired";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/intakeActorId.ttl
+++ b/NTO/Integration/attributes/intakeActorId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:intakeActorId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "intakeActorId";
+	dcterms:description "DPO intake clerk actor identifier.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/invocationAttempt.ttl
+++ b/NTO/Integration/attributes/invocationAttempt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:invocationAttempt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "invocationAttempt";
+	dcterms:description "One-based retry counter for the same actionId.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/jobState.ttl
+++ b/NTO/Integration/attributes/jobState.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:jobState
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "jobState";
+	dcterms:description "MergeJob / SplitJob state machine state. SplitJob states are PROPOSED -> VALIDATED -> SPLITTING -> COMPLETED | FAILED (Identity v2 Section 7.2). MergeJob is parallel with MERGING instead of SPLITTING (Identity v2 Section 6.3 -- state machine with the same crash-recovery checkpoint discipline as SplitJob).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "PROPOSED,VALIDATED,MERGING,SPLITTING,COMPLETED,FAILED";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/kafkaPartitions.ttl
+++ b/NTO/Integration/attributes/kafkaPartitions.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:kafkaPartitions
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "kafkaPartitions";
+	dcterms:description "Kafka topic partition count override (Sub-Q4 default 1).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/lastRecomputeAt.ttl
+++ b/NTO/Integration/attributes/lastRecomputeAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:lastRecomputeAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "lastRecomputeAt";
+	dcterms:description "Timestamp of the most recent posterior recomputation.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/legalBasis.ttl
+++ b/NTO/Integration/attributes/legalBasis.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:legalBasis
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "legalBasis";
+	dcterms:description "Legal basis citation (e.g. GDPR article reference, contract clause).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/legalBasisCitation.ttl
+++ b/NTO/Integration/attributes/legalBasisCitation.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:legalBasisCitation
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "legalBasisCitation";
+	dcterms:description "Citation of the legal basis for a retention override.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/legalRetentionOverride.ttl
+++ b/NTO/Integration/attributes/legalRetentionOverride.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:legalRetentionOverride
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "legalRetentionOverride";
+	dcterms:description "Flag that legal retention overrides the requested erasure.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "true,false";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/listSemanticsElementIdFrom.ttl
+++ b/NTO/Integration/attributes/listSemanticsElementIdFrom.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:listSemanticsElementIdFrom
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "listSemanticsElementIdFrom";
+	dcterms:description "CEL expression that derives a stable element identifier from a list-valued source element; mandatory when targetAttribute is list-valued (Mapping DSL Section 3.1 list_semantics block, validator V15 -- Cy R3 cluster N4).";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/listSemanticsOnIdCollision.ttl
+++ b/NTO/Integration/attributes/listSemanticsOnIdCollision.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:listSemanticsOnIdCollision
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "listSemanticsOnIdCollision";
+	dcterms:description "Behaviour when two source elements yield the same element identifier (Mapping DSL Section 3.1, Netting v2 Section 7.7.2 -- Cy R3 cluster N4).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "merge_metadata,reject";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/lockedVertexXid.ttl
+++ b/NTO/Integration/attributes/lockedVertexXid.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:lockedVertexXid
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "lockedVertexXid";
+	dcterms:description "External identifier of the vertex this ConflictLock holds (Identity v2 Section 5.3).";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/mappingRulesHash.ttl
+++ b/NTO/Integration/attributes/mappingRulesHash.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:mappingRulesHash
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "mappingRulesHash";
+	dcterms:description "Content hash of the captured mapping-rules payload.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/mappingRulesPayload.ttl
+++ b/NTO/Integration/attributes/mappingRulesPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:mappingRulesPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "mappingRulesPayload";
+	dcterms:description "Immutable JSON payload of the mapping rules captured for a Run.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/matchCriteria.ttl
+++ b/NTO/Integration/attributes/matchCriteria.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:matchCriteria
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "matchCriteria";
+	dcterms:description "Free-form predicate over both vertex sides.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/mergeNumericOperation.ttl
+++ b/NTO/Integration/attributes/mergeNumericOperation.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:mergeNumericOperation
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "mergeNumericOperation";
+	dcterms:description "Optional sub-operator for the expert_system_driven strategy when the CEL expression declares a numeric aggregation. F30 disposition 2026-06-02 (Variante B): kept as expert-strategy sub-operator, not as a strategy in its own right.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "sum,max,min,avg";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/mergeSetOperation.ttl
+++ b/NTO/Integration/attributes/mergeSetOperation.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:mergeSetOperation
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "mergeSetOperation";
+	dcterms:description "Optional sub-operator for the expert_system_driven strategy when the CEL expression declares a set-valued reconciliation. F30 disposition 2026-06-02 (Variante B): kept as expert-strategy sub-operator, not as a strategy in its own right.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "union,intersection,symmetric_difference";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/modelScope.ttl
+++ b/NTO/Integration/attributes/modelScope.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:modelScope
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "modelScope";
+	dcterms:description "global / override scope level of the conflict score model.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "global,override";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/nettingPolicyOverrideRef.ttl
+++ b/NTO/Integration/attributes/nettingPolicyOverrideRef.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:nettingPolicyOverrideRef
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "nettingPolicyOverrideRef";
+	dcterms:description "Optional per-instance override of the connector-default NettingPolicy. When set, this attribute takes precedence over any `appliesTo` edge from the connector-default NettingPolicy to this ConnectorInstance. The connector-default policy is the one declared by the owning Connector (via `declaresNettingPolicy -> NettingPolicy`); the override mechanism lets a specific instance opt out of that default without breaking the connector-level declaration. When the attribute is null, the `appliesTo` edge wins.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/nettingPolicyPayload.ttl
+++ b/NTO/Integration/attributes/nettingPolicyPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:nettingPolicyPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "nettingPolicyPayload";
+	dcterms:description "Immutable JSON payload of the netting policy captured for a Run.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/observedDistributionPayload.ttl
+++ b/NTO/Integration/attributes/observedDistributionPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:observedDistributionPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "observedDistributionPayload";
+	dcterms:description "Observed value distribution at drift detection time.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/operationType.ttl
+++ b/NTO/Integration/attributes/operationType.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:operationType
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "operationType";
+	dcterms:description "Blueprint-registered named operation for an Action-Outbound call (e.g. send_email).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/operatorActorId.ttl
+++ b/NTO/Integration/attributes/operatorActorId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:operatorActorId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "operatorActorId";
+	dcterms:description "Actor identifier of the operator emitting the signal.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/operatorNote.ttl
+++ b/NTO/Integration/attributes/operatorNote.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:operatorNote
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "operatorNote";
+	dcterms:description "[PII-BEARING] Free-form operator note attached to a decision-lifecycle entity. May contain subject names, identifiers, or other PII typed by the operator during adjudication. This attribute is only allowed on entities under `Decisions/PII/` (the RtE target); the framework rejects writes that attach `operatorNote` to an entity outside `Decisions/PII/`.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/overflowBufferBound.ttl
+++ b/NTO/Integration/attributes/overflowBufferBound.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:overflowBufferBound
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "overflowBufferBound";
+	dcterms:description "Maximum buffer size before overflow policy fires (D26.3).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/overflowPolicy.ttl
+++ b/NTO/Integration/attributes/overflowPolicy.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:overflowPolicy
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "overflowPolicy";
+	dcterms:description "Outbound overflow policy per D26.3 (buffer_drop_oldest / fail_loud).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "buffer_drop_oldest,fail_loud";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/overrideScopeId.ttl
+++ b/NTO/Integration/attributes/overrideScopeId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:overrideScopeId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "overrideScopeId";
+	dcterms:description "Override scope identifier when modelScope = override.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/preserveIntermediateStates.ttl
+++ b/NTO/Integration/attributes/preserveIntermediateStates.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:preserveIntermediateStates
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "preserveIntermediateStates";
+	dcterms:description "Per-MappingRule toggle: when true, the Coalescer lets every observed value through to the Hot-tier (TSDB-Provenance retains all values regardless). When false, intermediate states may be collapsed (Netting v2 Section 7.7.1 -- Cy R3 cluster N1).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "true,false";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/proposedTargetXids.ttl
+++ b/NTO/Integration/attributes/proposedTargetXids.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:proposedTargetXids
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "proposedTargetXids";
+	dcterms:description "List of at least two target-vertex identifiers the split job will create from one source vertex (Identity v2 Section 7.2). Serialised as a JSON array of vertex-id strings; OGIT has no native list datatype, so the framework parses the array at the persistence boundary and rejects arrays with fewer than two elements.";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/proposedValuePayload.ttl
+++ b/NTO/Integration/attributes/proposedValuePayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:proposedValuePayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "proposedValuePayload";
+	dcterms:description "[PII-BEARING] Proposed value payload from the conflicting incoming write. If the conflicting attribute is itself PII (name, email, identifier), this payload carries that PII verbatim. Allowed only on entities under `Decisions/PII/` (the RtE target); the framework rejects writes that attach `proposedValuePayload` to an entity outside `Decisions/PII/`.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/provenanceForced.ttl
+++ b/NTO/Integration/attributes/provenanceForced.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:provenanceForced
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "provenanceForced";
+	dcterms:description "Force provenance recording on a unidirectional MappingRule per D22 override.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "true,false";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/rateLimitBurst.ttl
+++ b/NTO/Integration/attributes/rateLimitBurst.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:rateLimitBurst
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "rateLimitBurst";
+	dcterms:description "Action invocation burst tolerance.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/rateLimitMaxPerMinute.ttl
+++ b/NTO/Integration/attributes/rateLimitMaxPerMinute.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:rateLimitMaxPerMinute
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "rateLimitMaxPerMinute";
+	dcterms:description "Action invocation rate limit ceiling (per minute, per instance).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/receivedAt.ttl
+++ b/NTO/Integration/attributes/receivedAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:receivedAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "receivedAt";
+	dcterms:description "Bardioc-side timestamp at which the user action was persisted.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/recoveryCount.ttl
+++ b/NTO/Integration/attributes/recoveryCount.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:recoveryCount
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "recoveryCount";
+	dcterms:description "Crash-recovery cycle counter for a MergeJob.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/relatedEntityRef.ttl
+++ b/NTO/Integration/attributes/relatedEntityRef.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:relatedEntityRef
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "relatedEntityRef";
+	dcterms:description "Optional reference from a UserAction to a related graph entity.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/requestPayload.ttl
+++ b/NTO/Integration/attributes/requestPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:requestPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "requestPayload";
+	dcterms:description "[PII-BEARING] Free-form payload of the SubjectRequest (scope, attributes affected, supporting documentation extracts). Subject Access Request payloads typically contain identifiers and contact data describing the requesting subject. Allowed only on entities under `Decisions/PII/` (the RtE target); the framework rejects writes that attach `requestPayload` to an entity outside `Decisions/PII/`.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/requestState.ttl
+++ b/NTO/Integration/attributes/requestState.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:requestState
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "requestState";
+	dcterms:description "DPO workflow state: intake / approved / executing / completed / rejected.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "intake,approved,executing,completed,rejected";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/requestType.ttl
+++ b/NTO/Integration/attributes/requestType.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:requestType
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "requestType";
+	dcterms:description "subject_access_request or right_to_erasure (Identity v2 Sec 21).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "subject_access_request,right_to_erasure";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/resolutionDecision.ttl
+++ b/NTO/Integration/attributes/resolutionDecision.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:resolutionDecision
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "resolutionDecision";
+	dcterms:description "Final decision payload for a decision-lifecycle entity.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/resolvedAt.ttl
+++ b/NTO/Integration/attributes/resolvedAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:resolvedAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "resolvedAt";
+	dcterms:description "Timestamp at which a decision-lifecycle entity reached a terminal state.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/resolverId.ttl
+++ b/NTO/Integration/attributes/resolverId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:resolverId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "resolverId";
+	dcterms:description "Identifier of the IdentityResolver that produced the candidate.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/resolverSubcomponentId.ttl
+++ b/NTO/Integration/attributes/resolverSubcomponentId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:resolverSubcomponentId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "resolverSubcomponentId";
+	dcterms:description "Sub-component of the resolver that produced this option (e.g. QID-match, name-blocking).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/reviewDecision.ttl
+++ b/NTO/Integration/attributes/reviewDecision.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:reviewDecision
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "reviewDecision";
+	dcterms:description "Reviewer decision (approve / reject / abstain).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "approve,reject,abstain";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/reviewNotes.ttl
+++ b/NTO/Integration/attributes/reviewNotes.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:reviewNotes
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "reviewNotes";
+	dcterms:description "[PII-FORBIDDEN] Free-form reviewer notes attached to a rule revision (MappingRule or ConflictResolutionRule). MUST NOT contain subject PII. The host entity (ReviewerOfRecord) is structural and survives Right-to-Erasure; a reviewer typing subject identifiers into this field creates a GDPR Art. 17 escape path. The framework's pre-persistence transform scans this field for known PII patterns (email regex, IBAN, well-known identifier shapes) and rejects writes that match. The [PII-FORBIDDEN] description prefix is a machine-greppable Almato convention.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/reviewerSignature.ttl
+++ b/NTO/Integration/attributes/reviewerSignature.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:reviewerSignature
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "reviewerSignature";
+	dcterms:description "Cryptographic signature of the reviewer.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/scheduleCron.ttl
+++ b/NTO/Integration/attributes/scheduleCron.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:scheduleCron
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "scheduleCron";
+	dcterms:description "Cron expression for the weaver execution schedule.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/scopeId.ttl
+++ b/NTO/Integration/attributes/scopeId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:scopeId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "scopeId";
+	dcterms:description "Compartmentalisation scope this instance operates in (DataScope per the platform model).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/scopeIds.ttl
+++ b/NTO/Integration/attributes/scopeIds.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:scopeIds
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "scopeIds";
+	dcterms:description "Set of scopes a ConnectorRun is authorised to write into. Serialised as a JSON array of scope-identifier strings; OGIT has no native list datatype, so the framework parses the array at the persistence boundary.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/signalAppliedAt.ttl
+++ b/NTO/Integration/attributes/signalAppliedAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:signalAppliedAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "signalAppliedAt";
+	dcterms:description "Timestamp at which the signal took effect (flush boundary).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/signalParametersPayload.ttl
+++ b/NTO/Integration/attributes/signalParametersPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:signalParametersPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "signalParametersPayload";
+	dcterms:description "Signal-specific parameters payload.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/signalType.ttl
+++ b/NTO/Integration/attributes/signalType.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:signalType
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "signalType";
+	dcterms:description "Operator-signal type: force_flush / pause / resume / re_snapshot / breaker_reset / breaker_disable / priority_bump.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "force_flush,pause,resume,re_snapshot,breaker_reset,breaker_disable,priority_bump";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/signingCertificateRef.ttl
+++ b/NTO/Integration/attributes/signingCertificateRef.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:signingCertificateRef
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "signingCertificateRef";
+	dcterms:description "Reference to the certificate used to sign the blueprint (Phase F).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/snapshotTakenAt.ttl
+++ b/NTO/Integration/attributes/snapshotTakenAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:snapshotTakenAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "snapshotTakenAt";
+	dcterms:description "Timestamp at which the config snapshot was frozen for a Run.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/sourceFieldPath.ttl
+++ b/NTO/Integration/attributes/sourceFieldPath.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:sourceFieldPath
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "sourceFieldPath";
+	dcterms:description "Path expression locating the source field in the source record (e.g. JSONPath or CEL expression).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/sourceIdempotencyHeader.ttl
+++ b/NTO/Integration/attributes/sourceIdempotencyHeader.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:sourceIdempotencyHeader
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "sourceIdempotencyHeader";
+	dcterms:description "HTTP header name a well-behaved source uses for idempotency (e.g. Idempotency-Key).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/sourcePriorityList.ttl
+++ b/NTO/Integration/attributes/sourcePriorityList.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:sourcePriorityList
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "sourcePriorityList";
+	dcterms:description "Fixed precedence list for the source-priority strategy.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/sourceRetryLimit.ttl
+++ b/NTO/Integration/attributes/sourceRetryLimit.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:sourceRetryLimit
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "sourceRetryLimit";
+	dcterms:description "Maximum source-side retries before declaring FAILED.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/sourceRetryOnFailure.ttl
+++ b/NTO/Integration/attributes/sourceRetryOnFailure.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:sourceRetryOnFailure
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "sourceRetryOnFailure";
+	dcterms:description "Retry behaviour on source-side dispatch failure: retry / fail.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "retry,fail";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/sourceSystemId.ttl
+++ b/NTO/Integration/attributes/sourceSystemId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:sourceSystemId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "sourceSystemId";
+	dcterms:description "Stable identifier of the external source system the connector connects to.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/sourceVersionCondition.ttl
+++ b/NTO/Integration/attributes/sourceVersionCondition.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:sourceVersionCondition
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "sourceVersionCondition";
+	dcterms:description "Optional SourceVersion-conditional applicability of this MappingRule (Identity v2 Sec 25).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/sourceVertexPattern.ttl
+++ b/NTO/Integration/attributes/sourceVertexPattern.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:sourceVertexPattern
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "sourceVertexPattern";
+	dcterms:description "Pattern matching candidate source-side vertices.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/sourceVertexXid.ttl
+++ b/NTO/Integration/attributes/sourceVertexXid.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:sourceVertexXid
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "sourceVertexXid";
+	dcterms:description "Source vertex being merged into the target.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/sovereigntyManifestPayload.ttl
+++ b/NTO/Integration/attributes/sovereigntyManifestPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:sovereigntyManifestPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "sovereigntyManifestPayload";
+	dcterms:description "Immutable JSON payload of the sovereignty manifest captured for a Run.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/strategy.ttl
+++ b/NTO/Integration/attributes/strategy.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:strategy
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "strategy";
+	dcterms:description "One of the seven D14 closed-set strategies or the D23 service-managed strategy (Identity v2 Section 6.1).";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "last_write_wins,source_priority,manual_review,expert_system_driven,time_window_bounded,constraint_derived,never_overwrite,service_managed";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/subjectIdentifier.ttl
+++ b/NTO/Integration/attributes/subjectIdentifier.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:subjectIdentifier
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "subjectIdentifier";
+	dcterms:description "[PII-RESTRICTED] [RBAC-ENFORCEMENT-PENDING-KC-PR] Data-subject identifier on a SubjectRequest. High-PII: access MUST be restricted to DPO roles. OGIT today has no field-level RBAC predicate; the restriction is a platform requirement on the Knowledge Core (concept doc Section 6.2, Knowledge Core dependencies). Because OGIT's create-time access model grants read on create, the gap between this OGIT PR merging and the Knowledge Core PR landing leaves `subjectIdentifier` unprotected on the read path: production use of `SubjectRequest` MUST be blocked until the KC PR lands (concept doc Section 7.2 ordering). The [PII-RESTRICTED] description prefix is a machine-greppable Almato convention: tooling rejects reads from any context outside an authenticated DPO session; the [RBAC-ENFORCEMENT-PENDING-KC-PR] marker is removed once the KC PR is merged.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/targetAttribute.ttl
+++ b/NTO/Integration/attributes/targetAttribute.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:targetAttribute
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "targetAttribute";
+	dcterms:description "Attribute (on the target vertex) the mapping rule writes to or reads from.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/targetInstanceId.ttl
+++ b/NTO/Integration/attributes/targetInstanceId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:targetInstanceId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "targetInstanceId";
+	dcterms:description "[DENORMALISED-CACHE] ConnectorInstance identifier the signal targets. Denormalised copy of the `targets -> ConnectorInstance` edge target, kept on the SignalEntity vertex so the per-instance stream-subscription key can be matched without a graph traversal (signals fan out by `instance_id` at high frequency). The framework re-derives the attribute from the edge whenever the edge changes; the edge is source of truth on divergence.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/targetResourceRef.ttl
+++ b/NTO/Integration/attributes/targetResourceRef.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:targetResourceRef
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "targetResourceRef";
+	dcterms:description "Source-side resource targeted by an Action invocation.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/targetVertexPattern.ttl
+++ b/NTO/Integration/attributes/targetVertexPattern.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:targetVertexPattern
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "targetVertexPattern";
+	dcterms:description "Pattern matching candidate target-side vertices.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/targetVertexType.ttl
+++ b/NTO/Integration/attributes/targetVertexType.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:targetVertexType
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "targetVertexType";
+	dcterms:description "OGIT vertex type the mapping rule targets.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/targetVertexXid.ttl
+++ b/NTO/Integration/attributes/targetVertexXid.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:targetVertexXid
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "targetVertexXid";
+	dcterms:description "Target vertex receiving the merge.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/testStatistic.ttl
+++ b/NTO/Integration/attributes/testStatistic.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:testStatistic
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "testStatistic";
+	dcterms:description "Numeric test-statistic value (e.g. chi-squared).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/timeWindowInnerStrategy.ttl
+++ b/NTO/Integration/attributes/timeWindowInnerStrategy.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:timeWindowInnerStrategy
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "timeWindowInnerStrategy";
+	dcterms:description "Sub-strategy applied within the timeWindowSeconds window for the time_window_bounded strategy. Any STRATEGY-NAME except time_window_bounded itself.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "last_write_wins,source_priority,manual_review,expert_system_driven,constraint_derived,never_overwrite,service_managed";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/timeWindowSeconds.ttl
+++ b/NTO/Integration/attributes/timeWindowSeconds.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:timeWindowSeconds
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "timeWindowSeconds";
+	dcterms:description "Window length in seconds for the time_window_bounded strategy. Writes within this window are reconciled by the timeWindowInnerStrategy; outside the window the more-recent write wins.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/triggerMode.ttl
+++ b/NTO/Integration/attributes/triggerMode.ttl
@@ -1,0 +1,16 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:triggerMode
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "triggerMode";
+	dcterms:description "D6 mode of operation for Data-Inbound: initial / delta / realtime.";
+	ogit:validation-type "fixed";
+	ogit:validation-parameter "initial,delta,realtime";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/triggeredAt.ttl
+++ b/NTO/Integration/attributes/triggeredAt.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:triggeredAt
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "triggeredAt";
+	dcterms:description "Source-system timestamp at which the user action occurred.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/ttlSeconds.ttl
+++ b/NTO/Integration/attributes/ttlSeconds.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ttlSeconds
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "ttlSeconds";
+	dcterms:description "Lock time-to-live in seconds; after acquiredAt + ttlSeconds the lock is reclaimable.";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/unrecognisedPayload.ttl
+++ b/NTO/Integration/attributes/unrecognisedPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:unrecognisedPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "unrecognisedPayload";
+	dcterms:description "[PII-PSEUDONYMISED-REQUIRED] Source-record payload that no MappingRule version recognises. MUST be pseudonymised by the framework's pre-persistence transform before it lands on a SchemaDriftCandidate vertex. SchemaDriftCandidate lives in the audit-forever Decisions/Audit/ namespace which survives Right-to-Erasure; raw PII from the source must not enter the audit-forever store. Schema-level enforcement is not possible in OGIT today; the constraint is checked by the framework at the persistence boundary (concept doc Section 6.2). The [PII-PSEUDONYMISED-REQUIRED] description prefix is a machine-greppable convention used by Almato tooling.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/userActionPayload.ttl
+++ b/NTO/Integration/attributes/userActionPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:userActionPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "userActionPayload";
+	dcterms:description "[PII-BEARING] Free-form payload of the user action. Subject to DSR / Right-to-Erasure purge. This attribute MUST only be used on entities under the Decisions/PII/ namespace (the RtE target). The [PII-BEARING] description prefix is a machine-greppable Almato convention: tooling rejects writes that attach this attribute to an entity outside Decisions/PII/.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/userActionType.ttl
+++ b/NTO/Integration/attributes/userActionType.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:userActionType
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "userActionType";
+	dcterms:description "Class of transient source event (button_click, slash_command, webhook_receive, approval_signal, etc.). Open-ended by design; no fixed validation per the README convention for descriptions ending in '... etc.'";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/userIdentifier.ttl
+++ b/NTO/Integration/attributes/userIdentifier.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:userIdentifier
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "userIdentifier";
+	dcterms:description "[PII-BEARING] Source-system user identifier. Subject to DSR / Right-to-Erasure purge. This attribute MUST only be used on entities under the Decisions/PII/ namespace (the RtE target). The [PII-BEARING] description prefix is a machine-greppable Almato convention: tooling rejects writes that attach this attribute to an entity outside Decisions/PII/.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/valueSetId.ttl
+++ b/NTO/Integration/attributes/valueSetId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:valueSetId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "valueSetId";
+	dcterms:description "Stable identifier of a CanonicalValueSet.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/versionSignature.ttl
+++ b/NTO/Integration/attributes/versionSignature.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:versionSignature
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "versionSignature";
+	dcterms:description "Optional cryptographic signature of the version declaration.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/vertexTtlDays.ttl
+++ b/NTO/Integration/attributes/vertexTtlDays.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:vertexTtlDays
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "vertexTtlDays";
+	dcterms:description "TTL for ActionInvocation vertices after terminal state. Default 90 (D34).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/vertexTtlDeadline.ttl
+++ b/NTO/Integration/attributes/vertexTtlDeadline.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:vertexTtlDeadline
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "vertexTtlDeadline";
+	dcterms:description "Scheduled hard-delete timestamp once the action reaches a terminal state.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/weaverId.ttl
+++ b/NTO/Integration/attributes/weaverId.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:weaverId
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "weaverId";
+	dcterms:description "Stable identifier of the weaver rule.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/attributes/weavingRulesPayload.ttl
+++ b/NTO/Integration/attributes/weavingRulesPayload.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:weavingRulesPayload
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "weavingRulesPayload";
+	dcterms:description "Immutable JSON payload of the weaving rules captured for a Run.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+.

--- a/NTO/Integration/entities/ActionPolicy.ttl
+++ b/NTO/Integration/entities/ActionPolicy.ttl
@@ -1,0 +1,52 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ActionPolicy
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "ActionPolicy";
+	dcterms:description """Per-operation-type policy block for Action-Outbound
+	operations. Sibling to NettingPolicy. Carries idempotency configuration
+	(dedupWindowSeconds, sourceIdempotencyHeader), the optional closure
+	specification (timeout, matchCriteria.data_path, matchCriteria.equals,
+	on_timeout policy, retry_limit), rate-limit parameters, breaker
+	configuration, and the vertexTtlDays for ActionInvocation cleanup.
+	authoritySource declares the authority-resolution logic for the
+	operationType per D35. Per PLAN D33; detail in
+	09_four_modes_concept.md Section 6.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:operationType
+		ogit.Integration:authoritySource
+		ogit.Integration:dedupWindowSeconds
+	);
+	ogit:optional-attributes (
+		ogit.Integration:sourceIdempotencyHeader
+		ogit.Integration:closureEnabled
+		ogit.Integration:closureTimeoutSeconds
+		ogit.Integration:closureMatchDataPath
+		ogit.Integration:closureMatchEquals
+		ogit.Integration:closureOnTimeout
+		ogit.Integration:closureRetryLimit
+		ogit.Integration:sourceRetryOnFailure
+		ogit.Integration:sourceRetryLimit
+		ogit.Integration:rateLimitMaxPerMinute
+		ogit.Integration:rateLimitBurst
+		ogit.Integration:breakerEnabled
+		ogit.Integration:breakerFailureThreshold
+		ogit.Integration:breakerCooldownSeconds
+		ogit.Integration:vertexTtlDays
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:operationType
+	);
+	ogit:allowed (
+		[ ogit.Integration:declaredBy ogit.Integration:Connector ]
+		[ ogit.Integration:appliesTo  ogit.Integration:ConnectorInstance ]
+	);
+.

--- a/NTO/Integration/entities/Adjudicator.ttl
+++ b/NTO/Integration/entities/Adjudicator.ttl
@@ -1,0 +1,36 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:Adjudicator
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "Adjudicator";
+	dcterms:description """Escalation authority for unresolved reviewer
+	disagreements. Carries the adjudicator identity, the rule revision the
+	adjudicator was called on, the final decision, and the signature.
+	Sibling to ReviewerOfRecord. Per Identity v2 Section 29 multi-team
+	governance.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:adjudicatorId
+		ogit:revision
+		ogit.Integration:adjudicationDecision
+		ogit.Integration:adjudicatedAt
+		ogit.Integration:adjudicatorSignature
+	);
+	ogit:optional-attributes (
+		ogit.Integration:adjudicationNotes
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:adjudicatorId
+		ogit.Integration:adjudicationDecision
+	);
+	ogit:allowed (
+		[ ogit.Integration:escalatedFrom ogit.Integration:ReviewerOfRecord ]
+	);
+.

--- a/NTO/Integration/entities/Authority.ttl
+++ b/NTO/Integration/entities/Authority.ttl
@@ -1,0 +1,40 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:Authority
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "Authority";
+	dcterms:description """First-class authority record per PLAN D24. Carries
+	the legal or organisational authority on whose behalf a write or action
+	was performed. Forms the queryable authority chain: an external auditor
+	traverses authorisedBy / processedBy edges to answer 'who authorised
+	this data write' or 'on whose authority was this side effect caused'.
+	D35 makes the authority_id mandatory for every ActionInvoker call;
+	calls without it are rejected with 403 missing_authority before reaching
+	the source system.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:authorityLabel
+		ogit.Integration:authorityType
+	);
+	ogit:optional-attributes (
+		ogit.Integration:legalBasis
+		ogit.Integration:authorityScopeId
+		ogit.Integration:authorityExternalRef
+		ogit:validFrom
+		ogit:validTo
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:authorityType
+		ogit.Integration:authorityScopeId
+	);
+	ogit:allowed (
+		[ ogit.Integration:delegatedFrom ogit.Integration:Authority ]
+	);
+.

--- a/NTO/Integration/entities/CanonicalValueSet.ttl
+++ b/NTO/Integration/entities/CanonicalValueSet.ttl
@@ -1,0 +1,35 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:CanonicalValueSet
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "CanonicalValueSet";
+	dcterms:description """Declared closed value set referenced from one or
+	more MappingRules. Used for value-domain-drift detection (Viktor fourth-
+	batch Comment 11): the framework tracks the chi-squared distribution
+	of incoming values against the canonical set; statistically significant
+	deviation surfaces as a ValueDriftCandidate for review. Per Identity v2
+	Section 27.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:valueSetId
+		ogit.Integration:allowedValuesPayload
+	);
+	ogit:optional-attributes (
+		ogit:description
+		ogit.Integration:driftChiSquaredThreshold
+		ogit.Integration:driftWindowDays
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:valueSetId
+	);
+	ogit:allowed (
+		[ ogit.Integration:referencedBy ogit.Integration:MappingRule ]
+	);
+.

--- a/NTO/Integration/entities/ConflictLock.ttl
+++ b/NTO/Integration/entities/ConflictLock.ttl
@@ -1,0 +1,46 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ConflictLock
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "ConflictLock";
+	dcterms:description """[DEPRECATED-ON-F9-LANDING] Operational infrastructure
+	entity that serialises concurrent writes against a single target vertex
+	when the Knowledge Core does not yet ship native If-Match optimistic
+	concurrency control. The holder claims the lock, performs the write or
+	merge, then releases it. The TTL provides a backstop reclamation path
+	in case the holder crashes. Lives outside Decisions/ because it carries
+	no per-Subject information (Identity v2 Section 5.3). When the Knowledge
+	Core ships native If-Match OCC via ogit/_v (PLAN F9), this entity, the
+	six attributes (lockedVertexXid, holderId, acquiredAt, ttlSeconds,
+	holderKind, expectedReleaseAt) and the four-step acquire-check-operate-
+	release protocol retire together in a follow-up OGIT PR. The concrete retirement mechanism is now on the table: the generic batch-operation facility's `preconditions` field with `expected_version` as the server-side If-Match (F6a follow-up; AO quorum question 2026-06-11, batch-occ-ifmatch). The locked vertex
+	is referenced by the lockedVertexXid attribute (a soft reference), not by an
+	edge: OGIT has no any-vertex edge target. Forward-compatible: blueprint code never sees the entity; it
+	is a kernel-internal mechanism. The [DEPRECATED-ON-F9-LANDING] prefix
+	is a machine-greppable Almato convention so tooling can suppress
+	permanent-binding generation. Viktor R3 Feedback 2026-06-01.""";
+	dcterms:valid "start=2026-05-29;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:lockedVertexXid
+		ogit.Integration:holderId
+		ogit.Integration:acquiredAt
+		ogit.Integration:ttlSeconds
+	);
+	ogit:optional-attributes (
+		ogit.Integration:holderKind
+		ogit.Integration:expectedReleaseAt
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:lockedVertexXid
+		ogit.Integration:holderId
+	);
+	ogit:allowed (
+	);
+.

--- a/NTO/Integration/entities/ConflictResolutionRule.ttl
+++ b/NTO/Integration/entities/ConflictResolutionRule.ttl
@@ -1,0 +1,45 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ConflictResolutionRule
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "ConflictResolutionRule";
+	dcterms:description """Per-attribute conflict resolution choice. Selects
+	one of the seven D14 closed-set strategies (last_write_wins,
+	source_priority, manual_review, expert_system_driven,
+	time_window_bounded, constraint_derived, never_overwrite;
+	canonical names per Identity v2 Section 6.1) OR the D23
+	service_managed strategy (framework-owned scoring with author-
+	seeded Beta-Posteriori updates). No bidirectional MappingRule may
+	exist without a corresponding ConflictResolutionRule -- framework
+	refuses Run start otherwise (D14 no-silent-defaults).""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:strategy
+		ogit.Integration:targetAttribute
+	);
+	ogit:optional-attributes (
+		ogit.Integration:sourcePriorityList
+		ogit.Integration:expertRuleExpression
+		ogit.Integration:mergeSetOperation
+		ogit.Integration:mergeNumericOperation
+		ogit.Integration:timeWindowSeconds
+		ogit.Integration:timeWindowInnerStrategy
+		ogit.Integration:constraintExpression
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:strategy
+		ogit.Integration:targetAttribute
+	);
+	ogit:allowed (
+		[ ogit.Integration:declaredBy        ogit.Integration:Connector ]
+		[ ogit.Integration:appliesToMapping  ogit.Integration:MappingRule ]
+		[ ogit:uses    ogit.Integration:ConflictScoreModel ]
+	);
+.

--- a/NTO/Integration/entities/ConflictScoreModel.ttl
+++ b/NTO/Integration/entities/ConflictScoreModel.ttl
@@ -1,0 +1,38 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ConflictScoreModel
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "ConflictScoreModel";
+	dcterms:description """Service-managed conflict resolution scoring per
+	D23. Holds per-source trust priors (author-seeded), accumulated
+	posterior updates from operator-supplied feedback, and the
+	Exponentially-Weighted-Moving-Average secondary tracking for retrospective
+	dual-algorithm comparison. Two-level granularity: a global model plus
+	per-scope override. The 'stable value being overwritten by a high-trust
+	source' signal is treated as HIGH-signal (Chris D23 inversion). The
+	model is framework-owned, not a per-connector implementation.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:modelScope
+		ogit.Integration:authorSeededPriorsPayload
+		ogit.Integration:betaPosterioriPayload
+	);
+	ogit:optional-attributes (
+		ogit.Integration:ewmaSecondaryPayload
+		ogit.Integration:overrideScopeId
+		ogit.Integration:lastRecomputeAt
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:modelScope
+		ogit.Integration:overrideScopeId
+	);
+	ogit:allowed (
+	);
+.

--- a/NTO/Integration/entities/Connector.ttl
+++ b/NTO/Integration/entities/Connector.ttl
@@ -1,0 +1,44 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:Connector
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "Connector";
+	dcterms:description """A published, versioned blueprint that defines a
+	connection between Bardioc and a single source system. Carries the
+	connector's mapping rules, netting policy default, conflict resolution
+	rules, weaving rules, action policy, optional identity-resolver
+	configuration, and code-surface handler references. A Connector is
+	instantiated at deploy time as one or more ConnectorInstances.
+	Per PLAN D6 (eight stages, three trigger modes) and D11 (NTO/Integration).""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit:version
+		ogit.Integration:frameworkMin
+		ogit.Integration:frameworkMax
+	);
+	ogit:optional-attributes (
+		ogit.Integration:sourceSystemId
+		ogit:author
+		ogit.Integration:signingCertificateRef
+		ogit.Integration:deprecationPhase
+	);
+	ogit:indexed-attributes (
+		ogit:version
+		ogit.Integration:sourceSystemId
+	);
+	ogit:allowed (
+		[ ogit.Integration:declaresMappingRule    ogit.Integration:MappingRule ]
+		[ ogit.Integration:declaresNettingPolicy  ogit.Integration:NettingPolicy ]
+		[ ogit.Integration:declaresConflictRule   ogit.Integration:ConflictResolutionRule ]
+		[ ogit.Integration:declaresWeavingRule    ogit.Integration:WeavingRule ]
+		[ ogit.Integration:declaresActionPolicy   ogit.Integration:ActionPolicy ]
+		[ ogit.Integration:declaresSourceVersion  ogit.Integration:SourceVersion ]
+	);
+.

--- a/NTO/Integration/entities/ConnectorInstance.ttl
+++ b/NTO/Integration/entities/ConnectorInstance.ttl
@@ -1,0 +1,44 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix ogit.Auth:            <http://www.purl.org/ogit/Auth/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ConnectorInstance
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "ConnectorInstance";
+	dcterms:description """One live deployment of a Connector against a
+	specific external system. A typical Bardioc deployment carries ~100-1000
+	ConnectorInstances; a DATAGROUP-scale customer operates roughly 200 per
+	tenant. Each Instance has its own endpoint configuration, its own
+	credentials reference, its own per-instance NettingPolicy override (if
+	any), and its own metrics. Per PLAN D6, D11.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:endpoint
+		ogit.Integration:credentialsRef
+		ogit.Integration:scopeId
+		ogit.Integration:customerId
+		ogit.Integration:instanceStatus
+		ogit.Integration:triggerMode
+	);
+	ogit:optional-attributes (
+		ogit.Integration:nettingPolicyOverrideRef
+		ogit.Integration:actionPolicyOverrideRef
+		ogit.Integration:dataMaturityTier
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:scopeId
+		ogit.Integration:customerId
+		ogit.Integration:instanceStatus
+	);
+	ogit:allowed (
+		[ ogit.Integration:instanceOf      ogit.Integration:Connector ]
+		[ ogit.Integration:operatesIn      ogit.Auth:DataScope ]
+		[ ogit.Integration:hasSignalEntity ogit.Integration:SignalEntity ]
+	);
+.

--- a/NTO/Integration/entities/ConnectorRun.ttl
+++ b/NTO/Integration/entities/ConnectorRun.ttl
@@ -1,0 +1,55 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ConnectorRun
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "ConnectorRun";
+	dcterms:description """One time-bounded execution of one ConnectorInstance.
+	**Immutable after create** per PLAN D28 with one allowed exception:
+	`endedAt` is the single permitted post-create mutation, written when
+	the run reaches a terminal state (completed / failed / aborted). All
+	other vertex attributes (startedAt, triggerMode, version,
+	scopeIds) are frozen at create. **Run lifecycle state (running /
+	completed / failed / aborted) is NOT stored on the vertex** -- it is
+	derived from the `lifecycle:<run_id>` TSDB stream and confirmed by
+	the presence and value of `endedAt`. The vertex has no `run_status`
+	attribute by design (PLAN D28). All additive state (lifecycle
+	transitions, cursor advances, statistics, operator and system events)
+	lives in four append-only TSDB streams keyed by the vertex's ogit/_id
+	(which doubles as the run_id in the stream-key patterns
+	lifecycle:<run_id>, cursor:<run_id>, stats:<run_id>, event:<run_id>
+	from PLAN D28). The `ConnectorRun -> ConnectorRunConfigSnapshot`
+	edge declaration is intentionally one-sided: `uses` is
+	declared only on `ConnectorRun.ogit:allowed`; the snapshot's
+	`ogit:allowed` stays empty. Whether this asymmetry is accepted
+	by the upstream OGIT validator is verified during the PR open
+	process (concept doc Section 7.1). A typical Bardioc deployment
+	generates ~100k ConnectorRuns per year.""";
+	dcterms:valid "start=2026-05-21;revised=2026-06-05;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit:startedAt
+		ogit.Integration:triggerMode
+		ogit:version
+	);
+	ogit:optional-attributes (
+		ogit.Integration:scopeIds
+		ogit:endedAt
+	);
+	ogit:indexed-attributes (
+		ogit:startedAt
+	);
+	ogit:allowed (
+		[ ogit:runsOn         ogit.Integration:ConnectorInstance ]
+		[ ogit.Integration:ofBlueprint   ogit.Integration:Connector ]
+		[ ogit.Integration:initiatedByActor   ogit:Agent ]
+		[ ogit:uses    ogit.Integration:ConnectorRunConfigSnapshot ]
+		[ ogit.Integration:authorisedBy  ogit.Integration:Authority ]
+		[ ogit.Integration:processedBy   ogit.Integration:Authority ]
+	);
+.

--- a/NTO/Integration/entities/ConnectorRunConfigSnapshot.ttl
+++ b/NTO/Integration/entities/ConnectorRunConfigSnapshot.ttl
@@ -1,0 +1,41 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ConnectorRunConfigSnapshot
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "ConnectorRunConfigSnapshot";
+	dcterms:description """Immutable per-Run vertex created at ConnectorRun
+	start. Captures the exact rule set the Run executes against -- mapping
+	rules, netting policy, identity-resolver configuration, conflict-
+	resolution rules, sovereignty manifest, weaving rules, action policy,
+	data-classification assignments -- as immutable JSON payloads or
+	hash-plus-payload pairs. Locks the Viktor-R2 invariant that rules and
+	configuration do not change during a Run; rule changes take effect on
+	the next Run. Per PLAN D28.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:snapshotTakenAt
+		ogit:version
+		ogit.Integration:mappingRulesHash
+		ogit.Integration:mappingRulesPayload
+		ogit.Integration:nettingPolicyPayload
+		ogit.Integration:conflictRulesPayload
+	);
+	ogit:optional-attributes (
+		ogit.Integration:identityResolverConfigPayload
+		ogit.Integration:sovereigntyManifestPayload
+		ogit.Integration:weavingRulesPayload
+		ogit.Integration:actionPolicyPayload
+		ogit.Integration:dataClassificationPayload
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:mappingRulesHash
+	);
+	ogit:allowed ( );
+.

--- a/NTO/Integration/entities/MappingRule.ttl
+++ b/NTO/Integration/entities/MappingRule.ttl
@@ -1,0 +1,48 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:MappingRule
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "MappingRule";
+	dcterms:description """Per-attribute mapping declaration. Translates one
+	or more source-system fields into a single graph-vertex attribute, or vice
+	versa. Carries the wire-shape declarations, the bidirectional flag, the
+	identity binding hint (deterministic key vs heuristic resolver per D20),
+	the optional CEL inline transform (D16), per-attribute conflict-rule
+	reference, optional canonical-value-set reference, and source-version
+	conditionals (D27 fourth-batch).""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:sourceFieldPath
+		ogit.Integration:targetVertexType
+		ogit.Integration:targetAttribute
+		ogit.Integration:bidirectional
+	);
+	ogit:optional-attributes (
+		ogit.Integration:bindBy
+		ogit.Integration:bindByResolver
+		ogit.Integration:celTransform
+		ogit.Integration:provenanceForced
+		ogit.Integration:expectedNeighbourhood
+		ogit.Integration:sourceVersionCondition
+		ogit.Integration:art22InScope
+		ogit.Integration:preserveIntermediateStates
+		ogit.Integration:listSemanticsElementIdFrom
+		ogit.Integration:listSemanticsOnIdCollision
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:targetAttribute
+		ogit.Integration:bidirectional
+	);
+	ogit:allowed (
+		[ ogit.Integration:declaredBy             ogit.Integration:Connector ]
+		[ ogit.Integration:bindsToConflictRule    ogit.Integration:ConflictResolutionRule ]
+		[ ogit.Integration:bindsToCanonicalValues ogit.Integration:CanonicalValueSet ]
+	);
+.

--- a/NTO/Integration/entities/NettingPolicy.ttl
+++ b/NTO/Integration/entities/NettingPolicy.ttl
@@ -1,0 +1,45 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:NettingPolicy
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "NettingPolicy";
+	dcterms:description """Write-side discipline declaration per
+	ConnectorInstance and direction (inbound / outbound). Carries the
+	coalescing-window parameters, the acknowledgement semantic, the
+	overflow policy, the circuit-breaker configuration (failure_threshold,
+	cooldown_seconds, self_heal), the durable-substrate selector, the
+	cursor + xid-upsert idempotency configuration. Per PLAN D26 with eight
+	sub-decisions plus D26.9 (Kafka as durable substrate).""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:direction
+		ogit.Integration:coalesceWindowSeconds
+		ogit.Integration:coalesceWindowEvents
+		ogit.Integration:ackSemantic
+		ogit.Integration:overflowPolicy
+	);
+	ogit:optional-attributes (
+		ogit.Integration:overflowBufferBound
+		ogit.Integration:breakerEnabled
+		ogit.Integration:breakerFailureThreshold
+		ogit.Integration:breakerCooldownSeconds
+		ogit.Integration:breakerSelfHeal
+		ogit.Integration:durableSubstrate
+		ogit.Integration:kafkaPartitions
+		ogit.Integration:droppedPayloadRetentionDays
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:direction
+	);
+	ogit:allowed (
+		[ ogit.Integration:declaredBy ogit.Integration:Connector ]
+		[ ogit.Integration:appliesTo  ogit.Integration:ConnectorInstance ]
+	);
+.

--- a/NTO/Integration/entities/ReviewerOfRecord.ttl
+++ b/NTO/Integration/entities/ReviewerOfRecord.ttl
@@ -1,0 +1,37 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ReviewerOfRecord
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "ReviewerOfRecord";
+	dcterms:description """Signed reviewer attestation for a Mapping- or
+	Conflict-Rule revision. Carries the reviewer identity, the version of
+	the rule under review, the review decision, and the signature payload.
+	Per Viktor fourth-batch Comment 13 multi-team governance (Identity v2
+	Section 29). Phase F deliverable for the certification gate.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit:reviewedBy
+		ogit:revision
+		ogit.Integration:reviewDecision
+		ogit:reviewedAt
+		ogit.Integration:reviewerSignature
+	);
+	ogit:optional-attributes (
+		ogit.Integration:reviewNotes
+	);
+	ogit:indexed-attributes (
+		ogit:reviewedBy
+		ogit.Integration:reviewDecision
+	);
+	ogit:allowed (
+		[ ogit:reviews ogit.Integration:MappingRule ]
+		[ ogit:reviews ogit.Integration:ConflictResolutionRule ]
+	);
+.

--- a/NTO/Integration/entities/SignalEntity.ttl
+++ b/NTO/Integration/entities/SignalEntity.ttl
@@ -1,0 +1,40 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:SignalEntity
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "SignalEntity";
+	dcterms:description """Operator command surface for connector instances.
+	Per PLAN D26.5, signals are first-class graph entities subscribed to by
+	the SignalConsumer component of the Netting layer via the Streaming API.
+	Supported signal types: force-flush, pause, resume, re-snapshot,
+	breaker-reset, breaker-disable (with audit), priority-bump. Signals are
+	applied at flush boundaries to keep the runtime semantics
+	well-defined.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:signalType
+		ogit.Integration:targetInstanceId
+		ogit.Integration:emittedAt
+		ogit.Integration:operatorActorId
+	);
+	ogit:optional-attributes (
+		ogit.Integration:signalParametersPayload
+		ogit:reason
+		ogit.Integration:signalAppliedAt
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:signalType
+		ogit.Integration:targetInstanceId
+	);
+	ogit:allowed (
+		[ ogit.Integration:targets   ogit.Integration:ConnectorInstance ]
+		[ ogit.Integration:emittedBy ogit:Agent ]
+	);
+.

--- a/NTO/Integration/entities/SourceVersion.ttl
+++ b/NTO/Integration/entities/SourceVersion.ttl
@@ -1,0 +1,36 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:SourceVersion
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "SourceVersion";
+	dcterms:description """First-class declaration of which source-system
+	version a ConnectorInstance is connected to. Used by version-conditional
+	MappingRules (Viktor fourth-batch Comment 9): when a source upgrade
+	changes field shapes, MappingRules can switch behaviour based on the
+	declared SourceVersion. A schema-drift queue picks up source records
+	that no MappingRule version recognises. Per Identity v2 Section 25.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:sourceSystemId
+		ogit:version
+		ogit.Integration:declaredAt
+	);
+	ogit:optional-attributes (
+		ogit.Integration:versionSignature
+		ogit.Integration:fieldsPayload
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:sourceSystemId
+		ogit:version
+	);
+	ogit:allowed (
+		[ ogit.Integration:appliesTo ogit.Integration:ConnectorInstance ]
+	);
+.

--- a/NTO/Integration/entities/WeavingRule.ttl
+++ b/NTO/Integration/entities/WeavingRule.ttl
@@ -1,0 +1,46 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:WeavingRule
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "WeavingRule";
+	dcterms:description """Cross-theme edge generation rule. Runs in the
+	Weaver phase (stage 4 of the eight-stage pipeline) AFTER one or more
+	ConnectorRuns finish, against the existing graph state. Reads graph
+	state across themes and produces additional edges between entities that
+	belong together by domain rules (e.g. linking a Ticket vertex to a User
+	vertex by name + system pair). A WeaverRun lifecycle entity (counterpart
+	to ConnectorRun for the Weaver phase) is a deferred Phase-G+ deliverable;
+	**in Phase B the audit trail for WeaverRule firings is stream-only**:
+	the Weaver writes activity into the ConnectorRun TSDB streams of the
+	owning connector instead of into a dedicated vertex. Implementers who
+	need to query which WeavingRules fired during a specific run MUST read
+	the `event:<run_id>` TSDB stream; no graph traversal path exists in
+	Phase B. The graph-level WeaverRun entity ships in Phase G+ together
+	with corresponding verbs.""";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:scope "NTO";
+	ogit:parent ogit:Node;
+	ogit:mandatory-attributes (
+		ogit.Integration:weaverId
+		ogit.Integration:sourceVertexPattern
+		ogit.Integration:targetVertexPattern
+		ogit.Integration:edgeType
+	);
+	ogit:optional-attributes (
+		ogit.Integration:matchCriteria
+		ogit.Integration:celPredicate
+		ogit.Integration:scheduleCron
+	);
+	ogit:indexed-attributes (
+		ogit.Integration:weaverId
+		ogit.Integration:edgeType
+	);
+	ogit:allowed (
+		[ ogit.Integration:declaredBy ogit.Integration:Connector ]
+	);
+.

--- a/NTO/Integration/verbs/appliesTo.ttl
+++ b/NTO/Integration/verbs/appliesTo.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:appliesTo
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "appliesTo";
+	dcterms:description "A NettingPolicy / ActionPolicy / SourceVersion applies to a specific ConnectorInstance. The verb has a polymorphic domain (three policy / version entity types) but a fixed range (ConnectorInstance); the shared range makes the polymorphism low-risk and the single edge name keeps instance-centric queries ('what applies to instance X?') readable. Documented and accepted as a multi-domain-single-range exception. The ConflictResolutionRule -> ConflictScoreModel link is NOT in this set; it is owned by `uses`.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2many";
+.

--- a/NTO/Integration/verbs/appliesToMapping.ttl
+++ b/NTO/Integration/verbs/appliesToMapping.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:appliesToMapping
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "appliesToMapping";
+	dcterms:description "A ConflictResolutionRule applies to one or more MappingRules.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "one2many";
+.

--- a/NTO/Integration/verbs/authorisedBy.ttl
+++ b/NTO/Integration/verbs/authorisedBy.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:authorisedBy
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "authorisedBy";
+	dcterms:description "A ConnectorRun, MergeJob, SplitJob, or ActionInvocation was authorised by a specific Authority.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/bindsToCanonicalValues.ttl
+++ b/NTO/Integration/verbs/bindsToCanonicalValues.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:bindsToCanonicalValues
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "bindsToCanonicalValues";
+	dcterms:description "A MappingRule binds to a CanonicalValueSet for value-drift detection. Semantic inverse of `referencedBy` (CanonicalValueSet -> MappingRule); see that verb's description for the rationale of keeping both directions as named verbs.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/bindsToConflictRule.ttl
+++ b/NTO/Integration/verbs/bindsToConflictRule.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:bindsToConflictRule
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "bindsToConflictRule";
+	dcterms:description "A MappingRule binds to a ConflictResolutionRule (mandatory for bidirectional attributes per D14).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/comparedAgainst.ttl
+++ b/NTO/Integration/verbs/comparedAgainst.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:comparedAgainst
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "comparedAgainst";
+	dcterms:description "A ValueDriftCandidate was compared against a CanonicalValueSet baseline.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/declaredBy.ttl
+++ b/NTO/Integration/verbs/declaredBy.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:declaredBy
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "declaredBy";
+	dcterms:description "Inverse of the various 'declares' verbs: a rule / policy / version was declared by a Connector blueprint.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/declaresActionPolicy.ttl
+++ b/NTO/Integration/verbs/declaresActionPolicy.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:declaresActionPolicy
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "declaresActionPolicy";
+	dcterms:description "A Connector blueprint declares an ActionPolicy for one or more operation_types.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "one2many";
+.

--- a/NTO/Integration/verbs/declaresConflictRule.ttl
+++ b/NTO/Integration/verbs/declaresConflictRule.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:declaresConflictRule
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "declaresConflictRule";
+	dcterms:description "A Connector blueprint declares a ConflictResolutionRule it ships with.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "one2many";
+.

--- a/NTO/Integration/verbs/declaresMappingRule.ttl
+++ b/NTO/Integration/verbs/declaresMappingRule.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:declaresMappingRule
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "declaresMappingRule";
+	dcterms:description "A Connector blueprint declares a MappingRule it ships with.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "one2many";
+.

--- a/NTO/Integration/verbs/declaresNettingPolicy.ttl
+++ b/NTO/Integration/verbs/declaresNettingPolicy.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:declaresNettingPolicy
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "declaresNettingPolicy";
+	dcterms:description "A Connector blueprint declares its default NettingPolicy.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "one2many";
+.

--- a/NTO/Integration/verbs/declaresSourceVersion.ttl
+++ b/NTO/Integration/verbs/declaresSourceVersion.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:declaresSourceVersion
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "declaresSourceVersion";
+	dcterms:description "A Connector blueprint declares the source-system versions it expects to interoperate with.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "one2many";
+.

--- a/NTO/Integration/verbs/declaresWeavingRule.ttl
+++ b/NTO/Integration/verbs/declaresWeavingRule.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:declaresWeavingRule
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "declaresWeavingRule";
+	dcterms:description "A Connector blueprint declares a WeavingRule it ships with.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "one2many";
+.

--- a/NTO/Integration/verbs/delegatedFrom.ttl
+++ b/NTO/Integration/verbs/delegatedFrom.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:delegatedFrom
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "delegatedFrom";
+	dcterms:description "An Authority is delegated from another Authority.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/detectedFor.ttl
+++ b/NTO/Integration/verbs/detectedFor.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:detectedFor
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "detectedFor";
+	dcterms:description "A ValueDriftCandidate was detected for a specific MappingRule; a SchemaDriftCandidate was detected for a specific ConnectorInstance. The verb has a polymorphic range (MappingRule from ValueDriftCandidate, ConnectorInstance from SchemaDriftCandidate); the source-entity type unambiguously determines the target type, so the polymorphism is documented and accepted. Splitting into `detectedForMapping` / `detectedForInstance` was considered and rejected because the two candidate types share the audit shape and a single edge name reads more naturally in drift-history queries.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/emittedBy.ttl
+++ b/NTO/Integration/verbs/emittedBy.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:emittedBy
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "emittedBy";
+	dcterms:description "A SignalEntity was emitted by an operator Actor.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/escalatedFrom.ttl
+++ b/NTO/Integration/verbs/escalatedFrom.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:escalatedFrom
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "escalatedFrom";
+	dcterms:description "An Adjudicator decision was escalated from a ReviewerOfRecord disagreement.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/hasOption.ttl
+++ b/NTO/Integration/verbs/hasOption.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:hasOption
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "hasOption";
+	dcterms:description "An IdentityCandidate has one or more IdentityCandidateOptions.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "one2many";
+.

--- a/NTO/Integration/verbs/hasSignalEntity.ttl
+++ b/NTO/Integration/verbs/hasSignalEntity.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:hasSignalEntity
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "hasSignalEntity";
+	dcterms:description "A ConnectorInstance has an attached SignalEntity (operator command).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "one2many";
+.

--- a/NTO/Integration/verbs/incumbentFrom.ttl
+++ b/NTO/Integration/verbs/incumbentFrom.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:incumbentFrom
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "incumbentFrom";
+	dcterms:description "A Conflict's incumbent value came from a specific ConnectorRun.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/initiatedByActor.ttl
+++ b/NTO/Integration/verbs/initiatedByActor.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:initiatedByActor
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "initiatedByActor";
+	dcterms:description "A ConnectorRun was initiated by a specific Actor (schedule, operator, engine policy).";
+	dcterms:valid "start=2026-06-05;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/initiatedByRun.ttl
+++ b/NTO/Integration/verbs/initiatedByRun.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:initiatedByRun
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "initiatedByRun";
+	dcterms:description "A MergeJob or SplitJob was initiated within a specific ConnectorRun. Allows type-safe traversal from a Decisions-namespace job to its originating ConnectorRun.";
+	dcterms:valid "start=2026-06-05;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/instanceOf.ttl
+++ b/NTO/Integration/verbs/instanceOf.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:instanceOf
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "instanceOf";
+	dcterms:description "A ConnectorInstance is an instance of a Connector blueprint.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/invokedBy.ttl
+++ b/NTO/Integration/verbs/invokedBy.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:invokedBy
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "invokedBy";
+	dcterms:description "An ActionInvocation was invoked from a specific ConnectorRun.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/ofBlueprint.ttl
+++ b/NTO/Integration/verbs/ofBlueprint.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:ofBlueprint
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "ofBlueprint";
+	dcterms:description "A ConnectorRun executed under a specific Connector blueprint version.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/operatesIn.ttl
+++ b/NTO/Integration/verbs/operatesIn.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:operatesIn
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "operatesIn";
+	dcterms:description "A ConnectorInstance operates in a named DataScope.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2many";
+.

--- a/NTO/Integration/verbs/processedBy.ttl
+++ b/NTO/Integration/verbs/processedBy.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:processedBy
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "processedBy";
+	dcterms:description "A ConnectorRun was processed on behalf of a specific Authority (may differ from authorisedBy in delegated cases).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/proposedBy.ttl
+++ b/NTO/Integration/verbs/proposedBy.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:proposedBy
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "proposedBy";
+	dcterms:description "A Conflict or IdentityCandidate was proposed by a specific ConnectorRun.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/receivedVia.ttl
+++ b/NTO/Integration/verbs/receivedVia.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:receivedVia
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "receivedVia";
+	dcterms:description "A UserAction was received via a specific ConnectorInstance.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/referencedBy.ttl
+++ b/NTO/Integration/verbs/referencedBy.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:referencedBy
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "referencedBy";
+	dcterms:description "A CanonicalValueSet is referenced by one or more MappingRules. Semantic inverse of `bindsToCanonicalValues` (MappingRule -> CanonicalValueSet). Both directions are kept as named verbs so traversal queries from either side stay first-class (value-set-centric audit views start from CanonicalValueSet; rule-centric drift detection starts from MappingRule).";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "one2many";
+.

--- a/NTO/Integration/verbs/relatedToVersion.ttl
+++ b/NTO/Integration/verbs/relatedToVersion.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:relatedToVersion
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "relatedToVersion";
+	dcterms:description "A SchemaDriftCandidate is related to (mismatches) a specific SourceVersion.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.

--- a/NTO/Integration/verbs/targets.ttl
+++ b/NTO/Integration/verbs/targets.ttl
@@ -1,0 +1,15 @@
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix ogit.Integration:     <http://www.purl.org/ogit/Integration/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+
+ogit.Integration:targets
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "targets";
+	dcterms:description "A SignalEntity targets a specific ConnectorInstance.";
+	dcterms:valid "start=2026-05-21;";
+	dcterms:creator "Almato AG";
+	ogit:cardinality "many2one";
+.


### PR DESCRIPTION
# NTO/Integration -- Bardioc Connector Framework 2.0 schema

## Summary

Adds the new top-level `NTO/Integration/` namespace to OGIT. It is the
schema substrate for the Bardioc Connector Framework 2.0: the four
in-graph rule registries (Mapping, Netting, Conflict-Resolution,
Weaving) plus the Connector / ConnectorInstance / ConnectorRun
lifecycle entities, the provenance and audit vocabulary, the conflict
and identity-reconciliation decision records, and the Action concept.

The change is purely additive and isolated: all 257 changed files live
under `NTO/Integration/`, nothing outside it is touched, and there are
no deletions.

## Scope

| Item | Count |
|---|---:|
| Entities | 27 (17 core + 7 `Decisions/PII` + 3 `Decisions/Audit`) |
| Attributes | 187 |
| Verbs | 39 |
| READMEs | 4 (NTO root + `Decisions/`, `Decisions/PII/`, `Decisions/Audit/`) |
| TTL files | 253 |
| Files total | 257 |
| Insertions | 4549 (0 deletions) |

## What it models

- **Registries (D7).** `MappingRule`, `NettingPolicy`,
  `ConflictResolutionRule`, `WeavingRule` -- the four registries are
  graph entities, not config files.
- **Lifecycle.** `Connector` (blueprint), `ConnectorInstance`
  (deployed configuration, `operatesIn -> ogit:DataScope`),
  `ConnectorRun` (immutable-after-start, with `ended_at` as the single
  allowed post-create mutation per PLAN D28), `ConnectorRunConfigSnapshot`
  (run-invariant rule set).
- **Provenance / conflict / identity.** `Authority` (8-field provenance
  tuple, D24), `Conflict`, `IdentityCandidate`/`IdentityCandidateOption`,
  `MergeJob`, `SplitJob`, `ConflictScoreModel` (service-managed scoring,
  D23), `Adjudicator`.
- **Action concept (D29-D36).** `ActionPolicy`, `ActionInvocation`.
- **PII vs Audit split.** `Decisions/PII/` holds the seven
  right-to-erasure target entities; `Decisions/Audit/` holds the three
  audit-forever entities (`ActionInvocation`, `SchemaDriftCandidate`,
  `ValueDriftCandidate`). The split keeps GDPR Art. 17 erasure targets
  disjoint from audit-forever records.

## Notable design points

- Polymorphic `initiatedBy` split into `initiatedByActor` +
  `initiatedByRun` (concrete edge targets; the validator rejects
  `ogit:Entity` as an edge target).
- `ConflictLock` carries a `[DEPRECATED-ON-F9-LANDING]` note -- it is a
  Phase-B-only construct, superseded once platform-level optimistic
  concurrency control lands.
- `credentials_ref` regex restricted to `vault` / `aws-sm` / `gcp-sm` /
  `azure-kv` / `k8s-secret` schemes; HTTP(S) is rejected.
- Seven machine-greppable framework-boundary marker prefixes in
  attribute descriptions: `[PII-CONDITIONAL]`,
  `[PII-PSEUDONYMISED-REQUIRED]`, `[PII-BEARING]`, `[PII-RESTRICTED]`,
  `[PII-FORBIDDEN]`, `[NULLED-ON-TERMINAL-STATE]`, `[OPERATOR-IAM-REF]`,
  `[SECRET-REF]`, `[DENORMALISED-CACHE]`, plus transient
  `[LEGAL-REVIEW-PENDING]` and `[RBAC-ENFORCEMENT-PENDING-KC-PR]`.

## OGIT-convention compliance

- `dcterms:creator "Almato AG"` on every one of the 253 TTL files
  (post arago-Almato merger discipline; no individual creator strings).
- Closed-enum and bool attributes carry `ogit:validation-type "fixed"`
  + `ogit:validation-parameter "<csv>"` (35 fixed attributes, all with
  a parameter; open-range attributes intentionally omit it).
- READMEs follow the `NTO/Auth` convention: one at the NTO root and one
  per named sub-group, none in the `attributes`/`entities`/`verbs` leaf
  directories.

## Validation

Local validation (the Java validator has a known Windows path bug;
rdflib-parse + a cross-reference check is the established local
alternative per the project QS checklist):

- rdflib parse: 253 TTL files, 2487 triples, **0 parse failures**.
- Cross-reference check: 27 entities, 187 attributes, 39 verbs;
  **0 orphan attribute files, 0 orphan verb files, 0 missing
  `Integration:` targets, 0 unknown `ogit:` refs**.

The authoritative OGIT validator (`bin/ogit-validator.jar`) runs at
PR-merge-time CI; it can be run pre-merge under Docker
(`eclipse-temurin:11-jre`) per the directory-mode-not-recursive
discipline (enumerate every `.ttl`, do not pass the directory).

## QS history

Six formal QS rounds plus a three-turn Opus-4.6 Dialog-QS. The Dialog-QS
converged on Turn 3 to **4/4/4/4** across Konsistenz / Funktionalitaet /
Sicherheit / Toter Code, which meets the two-model gate criterion.

One structural limitation is documented rather than schema-fixed: OGIT
today has no sensitivity vocabulary (`ogit:sensitive`,
`ogit:pii-bearing`, `ogit:access-classification`). Every PII / RBAC
contract in this PR is therefore framework-boundary-enforced, expressed
via the marker prefixes above and the "Framework-boundary contracts"
block (companion concept doc Section 6.2) with a residual-risk
acknowledgment. Moving these contracts from framework-boundary
enforcement to schema enforcement requires a separate OGIT
vocabulary-extension PR (listed under Follow-ups).

## Follow-ups (not in this PR)

- **OGIT sensitivity-vocabulary extension** -- would let the PII/RBAC
  contracts be schema-enforced instead of framework-boundary-enforced.
- **Knowledge Core RBAC PR** for field-level RBAC on `[PII-RESTRICTED]`
  attributes (`subject_identifier`). Opens **after** this PR merges;
  production use of `SubjectRequest` is blocked until it lands.
- **DPO + legal sign-off** on the `assigned_reviewer_id` classification
  (currently `[LEGAL-REVIEW-PENDING]`).

## Test plan

- [ ] `bin/ogit-validator.jar` over the full `NTO/Integration/` tree
      (enumerated file list, not directory mode) -- expected 0 errors.
- [ ] singleTTL bundle build includes the new `NTO/Integration/`
      classes cleanly.
- [ ] PURL ID registration for the `NTO/Integration/` namespace.
- [ ] Reviewer quorum sign-off: BOO (Chris Boos), VOS (Viktor Voss),
      BAR (Cy / Jens Bartsch); extended round: Andi, Pedro,
      OGIT maintainers.

## Companion documents

Concept and architecture specification (Almato-internal, not part of
this PR): Bardioc Connector Framework 2.0 Overview, Multi-Source
Identity v2, Netting, Mapping DSL, OGIT Extensions (`11_ogit_extensions.md`,
document changelog v1.0 -> v1.3).
